### PR TITLE
Added default font configuration for Linux.

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -31,7 +31,11 @@ const WindowsConfig: any = {
     "editor.fontFamily": "Consolas",
 }
 
-const DefaultPlatformConfig = Platform.isWindows() ? WindowsConfig : MacConfig
+const LinuxConfig: any = {
+    "editor.fontFamily": "DejaVu Sans Mono",
+}
+
+const DefaultPlatformConfig = Platform.isWindows() ? WindowsConfig : Platform.isLinux() ? LinuxConfig : MacConfig
 
 const userConfigFile = path.join(Platform.getUserHome(), ".oni", "config.json")
 

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -1,6 +1,7 @@
 import * as os from "os"
 
 export const isWindows = () => os.platform() === "win32"
+export const isLinux = () => os.platform() === "linux"
 
 export const getUserHome = () => {
     return isWindows() ? process.env["USERPROFILE"] : process.env["HOME"] // tslint:disable-line no-string-literal


### PR DESCRIPTION
Hello, I've added default font setting for linux. I chose DejaVu Sans Mono as it is usually already installed on most of the linux distributions. I've tested this solution on my machine which is running Fedora Workstation 25.