### PR TITLE
Added UI closing on commandline mode 

### DIFF
--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -136,6 +136,10 @@ const start = (args: string[]) => {
             UI.hideSignatureHelp()
         } else if (newMode === "insert") {
             UI.hideQuickInfo()
+        } else if (newMode === "cmdline") {
+            UI.hideCompletions()
+            UI.hideQuickInfo()
+
         }
     })
 


### PR DESCRIPTION
This only works in the latest version of neovim RPC. which was updated as of 8 days ago. I don't know how long it will be until that code makes its way into an update, but I could add a temporary fix in as well if you would like. I've set it to close autocompletions on the command line, but that could be changed if there is a need for vim-completions

#52 