### PR TITLE
Move colorscheme setting to defaults, rather than force it on load

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -62,8 +62,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             .then((nv) => {
                 console.log("NevoimInstance: Neovim started") // tslint:disable-line no-console
 
-                nv.command("colorscheme onedark")
-
                 // Workaround for issue where UI
                 // can fail to attach if there is a UI-blocking error
                 // nv.input("<ESC>")

--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -30,3 +30,5 @@ cnoremap :: <C-R>=fnameescape(expand('%:p:h'))<CR>/
 inoremap <expr> <C-a> pumvisible() ? "<Esc>A" : "<C-o>A"
 inoremap <expr> <C-b> pumvisible() ? "<Esc>bi" : "<C-o>b"
 inoremap <expr> <C-l> pumvisible() ? "<Esc>la" : "<C-o>a"
+
+colorscheme onedark


### PR DESCRIPTION
Related to #16 - there was a bug where the colorscheme was also being set to onedark. This likely caused errors for configs that didn't have that colorscheme, or at the very least caused problems because it would've overriden what was set in the init.vim.