### PR TITLE
Fix URL anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 ![alt text](./images/Oni_128.png)
 ## Neovim + JavaScript powered IDE
 
-- [Introduction](#Introduction)
-- [Features](#Features)
-- [Documentation](#Documentation)
-    - [Configuration](#Configuration)
-    - [Guide](#Guide)
-    - [Extensibility](#Extensibility)
-    - [FAQ](#FAQ)
-- [Roadmap](#Roadmap)
-- [License](#License)
-- [Contributing](#Contributing)
-- [Thanks](#Thanks)
+- [Introduction](#introduction)
+- [Features](#features)
+- [Documentation](#documentation)
+    - [Configuration](#configuration)
+    - [Guide](#guide)
+    - [Extensibility](#extensibility)
+    - [FAQ](#faq)
+- [Roadmap](#roadmap)
+- [License](#license)
+- [Contributing](#contributing)
+- [Thanks](#thanks)
 
 ## Introduction
 


### PR DESCRIPTION
It seems that the markdown parser will lowercase headers before writing the URL anchors hence before this commit https://github.com/extr0py/oni#Introduction will not work. After this commit it will be https://github.com/extr0py/oni#introduction and the anchors will work properly.