### PR TITLE
Add config property load init vim, independent of defaults - this way…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Here's an example config.json:
 ```
 {
     "oni.useDefaultConfig": true,
+    "oni.loadInitVim": true,
     "editor.fontSize": "14px",
     "editor.fontFamily": "Monaco",
     "editor.completions.enabled": true
@@ -132,7 +133,8 @@ Here's an example config.json:
 ```
 
 A few interesting configuration options to set:
-- `oni.useDefaultConfig` - ONI comes with an opinionated default set of plugins for a predictable out-of-box experience. This will be great for newcomes to ONI or Vim, but for Vim/Neovim veterans, this will likely conflict. Set this to `false` to avoid loading the default config, and to load settings from `init.vim` instead.
+- `oni.useDefaultConfig` - ONI comes with an opinionated default set of plugins for a predictable out-of-box experience. This will be great for newcomes to ONI or Vim, but for Vim/Neovim veterans, this will likely conflict. Set this to `false` to avoid loading the default config, and to load settings from `init.vim` instead (If this is false, it implies `oni.loadInitVim` is true)
+- `oni.loadInitVim` - This determines whether the user's `init.vim` is loaded. Use caution when setting this to `true` and setting `oni.useDefaultConfig` to true, as there could be conflicts with the default configuration.
 - `editor.fontSize` - Font size
 - `editor.fontFamily` - Font family
 - `prototype.editor.backgroundImageUrl` - specific a custom background image

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -23,6 +23,10 @@ const DefaultConfig: any = {
     // Set this to 'false' to avoid loading the default config, and load settings from init.vim instead.
     "oni.useDefaultConfig": true,
 
+    // By default, user's init.vim is not loaded, to avoid conflicts.
+    // Set this to `true` to enable loading of init.vim.
+    "oni.loadInitVim": false,
+
     "editor.fontSize": "14px",
     "editor.quickInfo.enabled": true,
     "editor.completions.enabled": true,

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -300,13 +300,14 @@ function startNeovim(runtimePaths: string[], args: any): Q.IPromise<any> {
 
     const joinedRuntimePaths = runtimePaths.join(",")
 
-    // If we are using the defaultConfig, suppress loading of the user's init.vim to avoid conflicts
-    // Setting -u NONE causes no plugins at all to load, but using a 'noop' still picks up the plugins
-    const vimRcArg = Config.getValue<boolean>("oni.useDefaultConfig") ? ["-u", noopInitVimPath] : []
+    const shouldLoadInitVim = Config.getValue<boolean>("oni.loadInitVim")
+    const useDefaultConfig = Config.getValue<boolean>("oni.useDefaultConfig")
+
+    const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
     const argsToPass = vimRcArg
-                        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "-N", "--embed", "--"])
-                        .concat(args)
+        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "-N", "--embed", "--"])
+        .concat(args)
 
     const nvimProc = cp.spawn(nvimProcessPath, argsToPass, {})
 


### PR DESCRIPTION
… init.vim can still be sourced even if the defaults are used