### PR TITLE
Fix #91, autocompletion after returning to insert mode

### DIFF
--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -202,9 +202,19 @@ const start = (args: string[]) => {
         if (UI.areCompletionsVisible()) {
 
             if (key === "<enter>") {
-                // Put a dummy character in front so it removes the word,
-                // but not a '.' if the completion comes directly after
-                instance.input("a<c-w>" + UI.getSelectedCompletion())
+                let completion = UI.getSelectedCompletion() || ''
+
+                //move one character left so the cursor is "within" the word
+                //(we wouldn't be displaying completions if there wasn't at least one character)
+                instance.input('<left>')
+                //get current word under cursor
+                instance.eval<string>("expand('<cword>')")
+                    .then((word) => {
+                        //move back to where we were
+                        instance.input('<right>')
+                        //remove the first instance of the word under the cursor
+                        instance.input(completion.replace(word,''))
+                    })
 
                 UI.hideCompletions()
                 return


### PR DESCRIPTION
In #91, you typed part of a word, exited insert mode, then re-entered insert mode and typed more characters.  Your "insert autocompletion" code was doing a `<C-w>` to delete the partial word you'd typed but that only deletes to the beginning of the characters entered since starting insert mode.

My solution is slightly less of a hack, but still a hack.  Move the cursor one character to the left, get the word under the cursor, and move the cursor back to the right.  This gets the "word" regardless of what was typed since starting insert mode.  I then remove this "word" prefix from the autocompletion string and insert what's left.  So the code makes the following assumptions:
1. There is a previous character to move the cursor under.  Given that you have to type at least one character to get the autocompletion pop-up to appear, I think this is a safe assumption.
2. The first part of the "word" you typed will be found at the beginning of the autocompletion string.  Today, this is true (it even has to be case-sensitive) but if we were to implement fuzzy-matching or case-insensitive autocompletion, it would fail.

I'm creating this Pull Request now mostly to request for comments.  The only other solution I can think of would be: exit insert mode, perform `db`, enter insert mode, insert unmodified autocompletion string.  Changing modes has side-effects though (like the `<C-w>` example above, and the small-delete register) and I wanted to minimize impact.  Thoughts?