### PR TITLE
Fix boundary cases in scrolling 

### DIFF
--- a/browser/src/Screen.ts
+++ b/browser/src/Screen.ts
@@ -238,8 +238,8 @@ export class NeovimScreen implements IScreen {
 
                 this._grid.setRegionFromGrid(regionToScroll, left, top)
 
-                for (let y = top; y < bottom; y++) {
-                    for (let x = left; x < right; x++) {
+                for (let y = top; y <= bottom; y++) {
+                    for (let x = left; x <= right; x++) {
                         this._deltaTracker.notifyCellModified(x, y)
                     }
                 }


### PR DESCRIPTION
Far right & very bottom line were not being re-rendered on scroll - missed boundary case.

Need to get some unit tests around here soon.