### PR TITLE
Initial fix for render issue

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -51,14 +51,17 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _pluginManager: PluginManager
     private _sessionWrapper: SessionWrapper
 
-    constructor(pluginManager: PluginManager, widthInPixels: number, heightInPixels: number, filesToOpen?: string[]) {
+    constructor(pluginManager: PluginManager, widthInPixels: number, heightInPixels: number) {
         super()
 
-        filesToOpen = filesToOpen || []
         this._pluginManager = pluginManager
 
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
+    }
+
+    public start(filesToOpen?: string[]): void {
+        filesToOpen = filesToOpen || []
 
         this._initPromise = startNeovim(this._pluginManager.getAllRuntimePaths(), filesToOpen)
             .then((nv) => {
@@ -117,9 +120,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     popupmenu_external: true,
                 }
 
+                const size = this._getSize()
+
                 // Workaround for bug in neovim/node-client
                 // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
-                this._neovim._session.request("nvim_ui_attach", [80, 40, startupOptions], (_err?: Error) => {
+                this._neovim._session.request("nvim_ui_attach", [size.cols, size.rows, startupOptions], (_err?: Error) => {
                     console.log("Attach success") // tslint:disable-line no-console
 
                     performance.mark("NeovimInstance.Plugins.Start")
@@ -219,10 +224,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
 
-        const rows = Math.floor(heightInPixels / this._fontHeightInPixels)
-        const cols = Math.floor(widthInPixels / this._fontWidthInPixels)
+        const size = this._getSize()
 
-        this._resizeInternal(rows, cols)
+        this._resizeInternal(size.rows, size.cols)
     }
 
     private _resizeInternal(rows: number, columns: number): void {
@@ -234,6 +238,12 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             console.warn("Overriding screen size based on debug.fixedSize")
         }
 
+        // If _initPromise isn't initialized, it means the UI hasn't attached to NeoVim
+        // yet. In that case, we don't need to call uiTryResize
+        if (!this._initPromise) {
+            return
+        }
+
         this._initPromise.then(() => {
             this._neovim.uiTryResize(columns, rows, (err?: Error) => {
                 if (err) {
@@ -241,6 +251,12 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 }
             })
         })
+    }
+
+    private _getSize() {
+        const rows = Math.floor(this._lastHeightInPixels / this._fontHeightInPixels)
+        const cols = Math.floor(this._lastWidthInPixels / this._fontWidthInPixels)
+        return { rows, cols}
     }
 
     private _handleNotification(_method: any, args: any): void {

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -48,6 +48,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _lastHeightInPixels: number
     private _lastWidthInPixels: number
 
+    private _rows: number
+    private _cols: number
+
     private _pluginManager: PluginManager
     private _sessionWrapper: SessionWrapper
 
@@ -121,6 +124,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 }
 
                 const size = this._getSize()
+                this._rows = size.rows
+                this._cols = size.cols
 
                 // Workaround for bug in neovim/node-client
                 // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
@@ -237,6 +242,13 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             columns = fixedSize.columns
             console.warn("Overriding screen size based on debug.fixedSize")
         }
+
+        if (rows === this._rows && columns === this._cols) {
+            return
+        }
+
+        this._rows = rows
+        this._cols = columns
 
         // If _initPromise isn't initialized, it means the UI hasn't attached to NeoVim
         // yet. In that case, we don't need to call uiTryResize

--- a/browser/src/Screen.ts
+++ b/browser/src/Screen.ts
@@ -192,6 +192,9 @@ export class NeovimScreen implements IScreen {
             case Actions.CLEAR:
                 this._grid.clear()
                 this._notifyAllCellsModified()
+
+                this._cursorColumn = 0
+                this._cursorRow = 0
                 break
             case Actions.RESIZE:
                 this._width = action.columns

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -37,7 +37,7 @@ const start = (args: string[]) => {
     let screen = new NeovimScreen(deltaRegion)
 
     const pluginManager = new PluginManager(screen, debugPlugin)
-    let instance = new NeovimInstance(pluginManager, document.body.offsetWidth, document.body.offsetHeight, parsedArgs._)
+    let instance = new NeovimInstance(pluginManager, document.body.offsetWidth, document.body.offsetHeight)
 
     const canvasElement = document.getElementById("test-canvas") as HTMLCanvasElement
     let renderer = new CanvasRenderer()
@@ -139,6 +139,11 @@ const start = (args: string[]) => {
         renderer.onAction(action)
         screen.dispatch(action)
 
+        UI.setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels)
+
+        renderer.update(screen, deltaRegion)
+        deltaRegion.cleanUpRenderedCells()
+
         UI.setColors(screen.foregroundColor)
 
         if (!pendingTimeout) {
@@ -166,8 +171,8 @@ const start = (args: string[]) => {
             UI.setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels)
         }
 
-        renderer.update(screen, deltaRegion)
-        deltaRegion.cleanUpRenderedCells()
+        // renderer.update(screen, deltaRegion)
+        // deltaRegion.cleanUpRenderedCells()
 
         window.requestAnimationFrame(() => renderFunction())
     }
@@ -185,6 +190,7 @@ const start = (args: string[]) => {
     }
 
     instance.setFont(Config.getValue<string>("editor.fontFamily"), Config.getValue<string>("editor.fontSize"))
+    instance.start(parsedArgs._)
 
     const mouse = new Mouse(canvasElement, screen)
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -139,11 +139,6 @@ const start = (args: string[]) => {
         renderer.onAction(action)
         screen.dispatch(action)
 
-        UI.setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels)
-
-        renderer.update(screen, deltaRegion)
-        deltaRegion.cleanUpRenderedCells()
-
         UI.setColors(screen.foregroundColor)
 
         if (!pendingTimeout) {
@@ -171,8 +166,8 @@ const start = (args: string[]) => {
             UI.setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels)
         }
 
-        // renderer.update(screen, deltaRegion)
-        // deltaRegion.cleanUpRenderedCells()
+        renderer.update(screen, deltaRegion)
+        deltaRegion.cleanUpRenderedCells()
 
         window.requestAnimationFrame(() => renderFunction())
     }


### PR DESCRIPTION
Turns out we are not handling the CLEAR action from NeoVim correctly. For CLEAR, the cursor should be reset back to 0, 0.

When we resize the screen (which, in the current flow, always happens since there is a default size set), the cursor position does not get reset - so that means the first text that is drawn is almost always in the wrong place.