### PR TITLE
Fix #51, signature separator and quickinfo text overflow

### DIFF
--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -11,13 +11,12 @@
         padding: 4px;
         box-shadow: 4px 4px rgba(0, 0, 0, 0.2);
         color: @text-color;
-        max-width: 500px;
+        text-overflow: ellipsis;
+        overflow: hidden;
 
         .title {
             width: 100%;
             white-space: nowrap;
-            text-overflow: ellipsis;
-            overflow: hidden;
             margin: 4px;
         }
 

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -108,17 +108,17 @@ const mapStateToSignatureHelpProps = (state: IState) => {
     } else {
         const currentItem = state.signatureHelp.items[state.signatureHelp.selectedItemIndex];
 
-        const argumentCount = state.signatureHelp.argumentCount
+        const maxIdx = currentItem.parameters.length - 1
 
         const parameters = currentItem.parameters.map((item, idx) => {
 
-            const sidx = Math.min(idx, currentItem.parameters.length)
-
             let currentText = item.text
-            if (idx < argumentCount)
+            if (idx < maxIdx)
                 currentText += currentItem.separator + " "
 
-            if (state.signatureHelp && sidx === state.signatureHelp.argumentIndex)
+            //check state.signatureHelp to avoid "Object is possibly 'null'" error
+            //even though we already checked it in the 'if' statement above
+            if (state.signatureHelp && idx === state.signatureHelp.argumentIndex)
                 return <SelectedText text={currentText} />
             else
                 return <Text text={currentText} />

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -29,7 +29,8 @@ export class QuickInfo extends React.Component<QuickInfoProps, void> {
             position: "absolute",
             bottom: "0px",
             opacity: this.props.visible ? 1 : 0,
-            whiteSpace: this.props.wrap ? "normal" : "nowrap"
+            whiteSpace: this.props.wrap ? "normal" : "nowrap",
+            'max-width': (document.body.offsetWidth - this.props.x - 40) + "px"
         }
 
         return <div key={"quickinfo-container"} className="quickinfo-container" style={containerStyle}>

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -108,21 +108,18 @@ const mapStateToSignatureHelpProps = (state: IState) => {
     } else {
         const currentItem = state.signatureHelp.items[state.signatureHelp.selectedItemIndex];
 
-        const maxIdx = currentItem.parameters.length - 1
-
         const parameters = currentItem.parameters.map((item, idx) => {
-
-            let currentText = item.text
-            if (idx < maxIdx)
-                currentText += currentItem.separator + " "
-
             //check state.signatureHelp to avoid "Object is possibly 'null'" error
             //even though we already checked it in the 'if' statement above
             if (state.signatureHelp && idx === state.signatureHelp.argumentIndex)
-                return <SelectedText text={currentText} />
+                return <SelectedText text={item.text} />
             else
-                return <Text text={currentText} />
+                return <Text text={item.text} />
         })
+        //insert ", " separator in between each parameter
+        for(let i=currentItem.parameters.length-1; i > 0; i-=1) {
+          parameters.splice(i, 0, <Text text={currentItem.separator + " "} />)
+        }
 
         let elements = [<Text text={currentItem.prefix} />]
             .concat(parameters)


### PR DESCRIPTION
Display ", " separator between parameters in method signature QuickInfo.  The main issue was `state.signatureHelp.argumentCount` always being 0.  Although after fixing that I changed the logic so the ", " isn't highlighted as part of the current parameter.

For text overflow, I changed the QuickInfo so it dynamically grows to the window edge (minus an arbitrary 40px to avoid the mini-map).  If the line is longer than the edge of the window, display ellipsis.  You can expand/shrink the oni window while QuickInfo is displayed and it will update its width accordingly.