### PR TITLE
Fix #94 - set g:gui_oni variable before loading init.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ A few interesting configuration options to set:
 - `prototype.editor.backgroundImageUrl` - specific a custom background image
 - `prototype.editor.backgroundImageSize` - specific a custom background size (cover, contain)
 
-See the `Config.ts` file for other interesting values to set
+See the `Config.ts` file for other interesting values to set.
+
+In VimL, the `g:gui_oni` variable will be set to `1`, and can be validated with `if exists("g:gui_oni")` in VimL.
 
 ### Extensibility
 

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -319,7 +319,7 @@ function startNeovim(runtimePaths: string[], args: any): Q.IPromise<any> {
     const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
     const argsToPass = vimRcArg
-        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "-N", "--embed", "--"])
+        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
         .concat(args)
 
     const nvimProc = cp.spawn(nvimProcessPath, argsToPass, {})


### PR DESCRIPTION
- Adds g:gui_oni variable so that ONI can be detected when initializing Vim, to differentiate for ONI-specific settings
- Update README