### PR TITLE
Update window title with current filename

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -327,6 +327,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 ))
             } else if (command === "resize") {
                 this.emit("action", Actions.resize(a[0][0], a[0][1]))
+            } else if (command === "set_title") {
+                this.emit("set-title", a[0][0])
             } else if (command === "eol_clear") {
                 this.emit("action", Actions.clearToEndOfLine())
             } else if (command === "clear") {
@@ -376,7 +378,7 @@ function startNeovim(runtimePaths: string[], args: any): Q.IPromise<any> {
     const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
     const argsToPass = vimRcArg
-        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
+        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "--cmd", "set title", "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
         .concat(args)
 
     const nvimProc = cp.spawn(nvimProcessPath, argsToPass, {})

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -156,6 +156,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     performance.mark("NeovimInstance.Plugins.Start")
                     this._pluginManager.startPlugins(this)
                     performance.mark("NeovimInstance.Plugins.End")
+
+                    // set title after attaching listeners so we can get the initial title
+                    this.command("set title")
                 })
             }, (err) => {
                 this.emit("error", err)
@@ -378,7 +381,7 @@ function startNeovim(runtimePaths: string[], args: any): Q.IPromise<any> {
     const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
     const argsToPass = vimRcArg
-        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "--cmd", "set title", "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
+        .concat(["--cmd", "set rtp+=" + joinedRuntimePaths, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
         .concat(args)
 
     const nvimProc = cp.spawn(nvimProcessPath, argsToPass, {})

--- a/browser/src/Services/WindowTitle.ts
+++ b/browser/src/Services/WindowTitle.ts
@@ -12,7 +12,7 @@ export class WindowTitle {
     constructor(neovimInstance: INeovimInstance) {
         neovimInstance.on("event", (name: string, context: any) => {
             if (name === "BufEnter") {
-                let filename: string = context.bufferFullPath
+                let filename = context.bufferFullPath
                 if ( ! filename) { // unnamed file
                     document.title = "ONI"
                     return

--- a/browser/src/Services/WindowTitle.ts
+++ b/browser/src/Services/WindowTitle.ts
@@ -1,0 +1,34 @@
+/**
+ * WindowTitle.ts
+ *
+ * Manages the window title
+ */
+
+import { INeovimInstance } from "./../NeovimInstance"
+import { isWindows } from "./../Platform"
+
+export class WindowTitle {
+
+    constructor(neovimInstance: INeovimInstance) {
+        neovimInstance.on("event", (name: string, context: any) => {
+            if (name === "BufEnter") {
+                let filename: string = context.bufferFullPath
+                if ( ! filename) { // unnamed file
+                    document.title = "ONI"
+                    return
+                }
+
+                // use the format "file (path) - ONI" to match GVIM format
+                let separator = isWindows() ? "\\" : "/"
+                let i = filename.lastIndexOf(separator)
+                if (i > -1) {
+                    let path = filename.slice(0, i + 1)
+                    filename = filename.slice(i + 1)
+                    document.title = filename + " (" + path + ") - ONI"
+                } else {
+                    document.title = filename + "- ONI"
+                }
+            }
+        })
+    }
+}

--- a/browser/src/Services/WindowTitle.ts
+++ b/browser/src/Services/WindowTitle.ts
@@ -26,7 +26,7 @@ export class WindowTitle {
                     filename = filename.slice(i + 1)
                     document.title = filename + " (" + path + ") - ONI"
                 } else {
-                    document.title = filename + "- ONI"
+                    document.title = filename + " - ONI"
                 }
             }
         })

--- a/browser/src/Services/WindowTitle.ts
+++ b/browser/src/Services/WindowTitle.ts
@@ -10,7 +10,7 @@ export class WindowTitle {
 
     constructor(neovimInstance: INeovimInstance) {
         neovimInstance.on("set-title", (title: string) => {
-            document.title = title.replace("NVIM", "ONI")
+            document.title = title.replace(" - NVIM", " - ONI")
         })
     }
 }

--- a/browser/src/Services/WindowTitle.ts
+++ b/browser/src/Services/WindowTitle.ts
@@ -5,30 +5,12 @@
  */
 
 import { INeovimInstance } from "./../NeovimInstance"
-import { isWindows } from "./../Platform"
 
 export class WindowTitle {
 
     constructor(neovimInstance: INeovimInstance) {
-        neovimInstance.on("event", (name: string, context: any) => {
-            if (name === "BufEnter") {
-                let filename = context.bufferFullPath
-                if ( ! filename) { // unnamed file
-                    document.title = "ONI"
-                    return
-                }
-
-                // use the format "file (path) - ONI" to match GVIM format
-                let separator = isWindows() ? "\\" : "/"
-                let i = filename.lastIndexOf(separator)
-                if (i > -1) {
-                    let path = filename.slice(0, i + 1)
-                    filename = filename.slice(i + 1)
-                    document.title = filename + " (" + path + ") - ONI"
-                } else {
-                    document.title = filename + " - ONI"
-                }
-            }
+        neovimInstance.on("set-title", (title: string) => {
+            document.title = title.replace("NVIM", "ONI")
         })
     }
 }

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -18,6 +18,7 @@ import { OutputWindow } from "./Services/Output"
 import { QuickOpen } from "./Services/QuickOpen"
 import { SyntaxHighlighter } from "./Services/SyntaxHighlighter"
 import { Tasks } from "./Services/Tasks"
+import { WindowTitle } from "./Services/WindowTitle"
 import * as UI from "./UI/index"
 import { ErrorOverlay } from "./UI/Overlay/ErrorOverlay"
 import { LiveEvaluationOverlay } from "./UI/Overlay/LiveEvaluationOverlay"
@@ -50,6 +51,7 @@ const start = (args: string[]) => {
     // Services
     const errorService = new Errors(instance)
     const quickOpen = new QuickOpen(instance)
+    const windowTitle = new WindowTitle(instance)
     const multiProcess = new MultiProcess()
     const formatter = new Formatter(instance, pluginManager)
     const outputWindow = new OutputWindow(instance, pluginManager)
@@ -61,6 +63,7 @@ const start = (args: string[]) => {
 
     services.push(errorService)
     services.push(quickOpen)
+    services.push(windowTitle)
     services.push(tasks)
     services.push(formatter)
     services.push(liveEvaluation)


### PR DESCRIPTION
When a file is loaded, update the window title with the current filename similar to GVIM's format.

Note that at startup, the `set_title` event may fire before we've set the event listener, causing the title to be `ONI` until a different file is loaded.  I don't know how to query the `title` property after connecting to neovim to ensure we have the initial value so I only call `:set title` after all event listeners are set.  This is a bit of a hack but it means we'll never miss that first event.