### PR TITLE
add attribution for default background image

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -3,3 +3,5 @@
 ## Audio
 beep.md - CC0 - http://opengameart.org/content/atmospheric-interaction-sound-pack
 
+## Images
+default background.png, "Dark Sharp Edges" - CC BY-SA 3.0 - https://www.toptal.com/designers/subtlepatterns


### PR DESCRIPTION
The default background I committed earlier is available via Creative Commons but that requires attribution.  I'm not sure what format you want `ASSETS.md` to be in so I just took a guess.