### PR TITLE
Replace edit menu with one that matches gvim

### DIFF
--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -292,6 +292,10 @@ const start = (args: string[]) => {
     window["neovim"] = instance // tslint:disable-line no-string-literal
 
     UI.init()
+
+    ipcRenderer.on("menu-item-click", (_evt, message) => {
+        instance.command("normal! " + message)
+    })
 }
 
 ipcRenderer.on("init", (_evt, message) => {

--- a/main.js
+++ b/main.js
@@ -68,6 +68,66 @@ function createWindow(commandLineArguments, workingDirectory) {
         ]
     })
 
+    menu[1].submenu = [
+       {
+           label: 'Undo',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", "u")
+           }
+       },
+       {
+           label: 'Redo',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", "\<C-r>")
+           }
+       },
+       {
+           label: 'Repeat',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", ".")
+           }
+       },
+       {
+           type: 'separator'
+       },
+       {
+           label: 'Cut',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", '"+x')
+           }
+       },
+       {
+           label: 'Copy',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", '"+y')
+           }
+       },
+       {
+           label: 'Paste',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", '"+gP')
+           }
+       },
+       {
+           label: 'Put Before',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", "[p")
+           }
+       },
+       {
+           label: 'Put After',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", "]p")
+           }
+       },
+       {
+           label: 'Select All',
+           click: (item, focusedWindow) => {
+               mainWindow.webContents.send("menu-item-click", "ggVG")
+           }
+       },
+    ]
+
     menu[4].submenu = [
         {
             label: 'Learn more',


### PR DESCRIPTION
The default Edit menu provided by Electron doesn't communicate with NeoVim so the options don't actually work.  This Pull Request replaces the Edit menu with the options found in GVim.

Unfortunately, Electron won't allow for accelerators (key shortcuts) to be lower-case so it refuses to display things like `ggVG` as an accelerator.  I think we'd have to create a custom display of the accelerators to do that.  For now, I'm just not displaying any accelerators.

Also, the `Redo` operation should be `^R` or `<C-r>` but I can't figure out how to get that stupid thing to work.  So everything in this Pull Request works except `Redo`.  I decided to just create this Pull Request now in the hopes that someone might be able to figure out how to get the `Redo` command to work.  Besides, the default Edit menu is completely useless so at least this Edit menu is *mostly* functional. :smile: 