### PR TITLE
This worked for me for #196 (Fix for the fix)

### DIFF
--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -294,7 +294,7 @@ const start = (args: string[]) => {
     UI.init()
 
     ipcRenderer.on("menu-item-click", (_evt, message) => {
-        instance.command("normal! " + message)
+        instance.command("exec \":normal! " + message + "\"")
     })
 }
 

--- a/main.js
+++ b/main.js
@@ -93,19 +93,19 @@ function createWindow(commandLineArguments, workingDirectory) {
        {
            label: 'Cut',
            click: (item, focusedWindow) => {
-               mainWindow.webContents.send("menu-item-click", '"+x')
+               mainWindow.webContents.send("menu-item-click", '\\"+x')
            }
        },
        {
            label: 'Copy',
            click: (item, focusedWindow) => {
-               mainWindow.webContents.send("menu-item-click", '"+y')
+               mainWindow.webContents.send("menu-item-click", '\\"+y')
            }
        },
        {
            label: 'Paste',
            click: (item, focusedWindow) => {
-               mainWindow.webContents.send("menu-item-click", '"+gP')
+               mainWindow.webContents.send("menu-item-click", '\\"+gP')
            }
        },
        {

--- a/main.js
+++ b/main.js
@@ -78,7 +78,7 @@ function createWindow(commandLineArguments, workingDirectory) {
        {
            label: 'Redo',
            click: (item, focusedWindow) => {
-               mainWindow.webContents.send("menu-item-click", "\<C-r>")
+               mainWindow.webContents.send("menu-item-click", "\\<C-r>")
            }
        },
        {


### PR DESCRIPTION
If we want to move over to a feedkeys implementation as justinmk suggested, we could do that, but this will get them going in the mean time.

EDIT: Actually, as justinmk noted, feed keys is probably not the optimal method for using normal! programatically. This PR fixes the other menu items by properly escaping them.