### PR TITLE
Fix #161 - Don't send empty errors for files over IPC

### DIFF
--- a/plugin_api/src/Diagnostics.ts
+++ b/plugin_api/src/Diagnostics.ts
@@ -5,8 +5,11 @@ import * as Sender from "./Sender"
  */
 export class Diagnostics implements Oni.Plugin.Diagnostics.Api { 
 
+    constructor(private _sender: Sender.ISender = new Sender.IpcSender) {
+    }
+
     public setErrors(key: string, fileName: string, errors: Oni.Plugin.Diagnostics.Error[], color?: string): void {
-        Sender.send("set-errors", null, {
+        this._sender.send("set-errors", null, {
             key: key,
             fileName: fileName,
             errors: errors,
@@ -15,7 +18,7 @@ export class Diagnostics implements Oni.Plugin.Diagnostics.Api {
     }
 
     public clearErrors(key: string): void {
-        Sender.send("clear-errors", null, {
+        this._sender.send("clear-errors", null, {
             key: key
         })
     }

--- a/plugin_api/src/Diagnostics.ts
+++ b/plugin_api/src/Diagnostics.ts
@@ -3,12 +3,22 @@ import * as Sender from "./Sender"
 /**
  * API instance for interacting with Oni (and vim)
  */
-export class Diagnostics implements Oni.Plugin.Diagnostics.Api { 
+export class Diagnostics implements Oni.Plugin.Diagnostics.Api {
+    private _filesThatHaveErrors: { [fileName: string]: boolean } = {}
 
     constructor(private _sender: Sender.ISender = new Sender.IpcSender) {
     }
 
     public setErrors(key: string, fileName: string, errors: Oni.Plugin.Diagnostics.Error[], color?: string): void {
+
+        if (!errors)
+            return
+
+        if (errors.length === 0 && !this._filesThatHaveErrors[fileName])
+            return
+
+        this._filesThatHaveErrors[fileName] = errors.length > 0
+
         this._sender.send("set-errors", null, {
             key: key,
             fileName: fileName,
@@ -18,6 +28,7 @@ export class Diagnostics implements Oni.Plugin.Diagnostics.Api {
     }
 
     public clearErrors(key: string): void {
+        this._filesThatHaveErrors = {}
         this._sender.send("clear-errors", null, {
             key: key
         })

--- a/plugin_api/src/Editor.ts
+++ b/plugin_api/src/Editor.ts
@@ -5,8 +5,11 @@ import * as Sender from "./Sender"
  */
 export class Editor implements Oni.Editor { 
 
+    constructor(private _sender: Sender.ISender = new Sender.IpcSender) {
+    }
+
     public executeShellCommand(shellCommand: string) {
-        Sender.send("execute-shell-command", null, {
+        this._sender.send("execute-shell-command", null, {
             command: shellCommand
         })
     }

--- a/plugin_api/src/Sender.ts
+++ b/plugin_api/src/Sender.ts
@@ -5,29 +5,39 @@ import { remote } from "electron"
 const id = remote.getCurrentWebContents().id
 
 /**
- * Helper function to send request to main handler using ipc
+ * Interface that describes a strategy for sending data
+ * to the main process from the plugin
  */
-export function send(type: string, originalEventContext: any, payload: any): void {
-    ipcRenderer.send("cross-browser-ipc", {
-        type: type,
-        meta: {
-            senderId: id,
-            destinationId: global["SourceBrowserId"],
-            originEvent: originalEventContext
-        },
-        payload: payload
-    })
+export interface ISender {
+    send(type: string, originalEventContext: any, payload: any): void
+    sendError(type: string, originalEventContext: any, error: string): void
 }
 
-export function sendError(type: string, originalEventContext: any, error: string): void {
-    ipcRenderer.send("cross-browser-ipc", {
-        type: type,
-        meta: {
-            senderId: id,
-            destinationId: global["SourceBrowserId"],
-            originEvent: originalEventContext
-        },
-        error: error
-    })
-}
+/**
+ * Implementation of ISender leverage IPC
+ */
+export class IpcSender {
+    public send(type: string, originalEventContext: any, payload: any): void {
+        ipcRenderer.send("cross-browser-ipc", {
+            type: type,
+            meta: {
+                senderId: id,
+                destinationId: global["SourceBrowserId"],
+                originEvent: originalEventContext
+            },
+            payload: payload
+        })
+    }
 
+    public sendError(type: string, originalEventContext: any, error: string): void {
+        ipcRenderer.send("cross-browser-ipc", {
+            type: type,
+            meta: {
+                senderId: id,
+                destinationId: global["SourceBrowserId"],
+                originEvent: originalEventContext
+            },
+            error: error
+        })
+    }
+}

--- a/plugin_api/src/Sender.ts
+++ b/plugin_api/src/Sender.ts
@@ -2,7 +2,6 @@ import { ipcRenderer } from "electron"
 
 import { remote } from "electron"
 
-const id = remote.getCurrentWebContents().id
 
 /**
  * Interface that describes a strategy for sending data
@@ -17,11 +16,17 @@ export interface ISender {
  * Implementation of ISender leverage IPC
  */
 export class IpcSender {
+    private _id: number
+
+    constructor() {
+        this._id = remote.getCurrentWebContents().id
+    }
+
     public send(type: string, originalEventContext: any, payload: any): void {
         ipcRenderer.send("cross-browser-ipc", {
             type: type,
             meta: {
-                senderId: id,
+                senderId: this._id,
                 destinationId: global["SourceBrowserId"],
                 originEvent: originalEventContext
             },
@@ -33,7 +38,7 @@ export class IpcSender {
         ipcRenderer.send("cross-browser-ipc", {
             type: type,
             meta: {
-                senderId: id,
+                senderId: this._id,
                 destinationId: global["SourceBrowserId"],
                 originEvent: originalEventContext
             },

--- a/plugin_api/test/DiagnosticsTests.ts
+++ b/plugin_api/test/DiagnosticsTests.ts
@@ -3,6 +3,47 @@ import * as assert from "assert"
 import { Diagnostics } from "./../src/Diagnostics"
 import { ISender } from "./../src/Sender"
 
+describe("Diagnostics", () => {
+    let diagnostics: Diagnostics
+    let mockSender: MockSender
+
+    beforeEach(() => {
+        mockSender = new MockSender()
+        diagnostics = new Diagnostics(mockSender)
+    })
+
+    it("sends errors for a file", () => {
+        diagnostics.setErrors("test-plugin", "someFile.ts", [{
+            lineNumber: 1,
+            startColumn: 0,
+            endColumn: 1,
+            type: "error",
+            text: "some error"
+        }], "red")
+
+        assert.strictEqual(mockSender.sentMessages.length, 1)
+    })
+
+    it("does not send errors for a file if there have never been any errors", () => {
+        diagnostics.setErrors("test-plugin", "someFile.ts", [], "red")
+
+        assert.strictEqual(mockSender.sentMessages.length, 0)
+    })
+
+    it("does send empty errors array, if there have been errors previously", () => {
+        diagnostics.setErrors("test-plugin", "someFile.ts", [{
+            lineNumber: 1,
+            startColumn: 0,
+            endColumn: 1,
+            type: "error",
+            text: "some error"
+        }], "red")
+
+        diagnostics.setErrors("test-plugin", "someFile.ts", [], "red")
+        assert.strictEqual(mockSender.sentMessages.length, 2)
+    })
+})
+
 class MockSender implements ISender {
     private _sentMessages: any[] = []
     private _sentErrors: any[] = []
@@ -31,26 +72,3 @@ class MockSender implements ISender {
         })
     }
 }
-
-describe("Diagnostics", () => {
-    let diagnostics: Diagnostics;
-    let mockSender: ISender;
-
-    beforeEach(() => {
-        mockSender = new MockSender();
-        diagnostics = new Diagnostics(mockSender);
-    });
-
-    it("sends errors for a file", () => {
-        assert.ok(false);
-    });
-
-    it("does not send errors for a file if there have never been any errors", () => {
-        assert.ok(false);
-    });
-
-    it("does send empty errors array, if there have been errors previously", () => {
-        assert.ok(false);
-    });
-})
-

--- a/plugin_api/test/DiagnosticsTests.ts
+++ b/plugin_api/test/DiagnosticsTests.ts
@@ -1,0 +1,56 @@
+import * as assert from "assert"
+
+import { Diagnostics } from "./../src/Diagnostics"
+import { ISender } from "./../src/Sender"
+
+class MockSender implements ISender {
+    private _sentMessages: any[] = []
+    private _sentErrors: any[] = []
+
+    public get sentMessages(): any[] {
+        return this._sentMessages
+    }
+
+    public get sentErrors(): any[] {
+        return this._sentErrors
+    }
+
+    public send(type: string, originalEvent: any, payload: any): void {
+        this._sentMessages.push({
+            type,
+            originalEvent,
+            payload
+        })
+    }
+
+    public sendError(type: string, originalEvent: any, error: string): void {
+        this._sentErrors.push({
+            type,
+            originalEvent,
+            error
+        })
+    }
+}
+
+describe("Diagnostics", () => {
+    let diagnostics: Diagnostics;
+    let mockSender: ISender;
+
+    beforeEach(() => {
+        mockSender = new MockSender();
+        diagnostics = new Diagnostics(mockSender);
+    });
+
+    it("sends errors for a file", () => {
+        assert.ok(false);
+    });
+
+    it("does not send errors for a file if there have never been any errors", () => {
+        assert.ok(false);
+    });
+
+    it("does send empty errors array, if there have been errors previously", () => {
+        assert.ok(false);
+    });
+})
+


### PR DESCRIPTION
Fix for #161 - there is a lot of churn over IPC for large typescript projects (and, once other language providers are created, any large project). The typescript provider sends up frequent messages for files it has scanned. Potentially this can be improved on the typescript side, but on the language provider side, we can filter these out as well, which makes it more robust for any language provider.

This implements a test for the diagnostics provider that hits the case (sending empty errors up shouldn't send an IPC message, unless we've seen an error before). As a pre-req to implement the test case, the `Sender` strategy was factored to an interface.

For #171, some initial performance investigation has shown that the IPC calls are expensive - even when they are async - so a potential avenue would be replacing the `IpcSender` with a socket-based strategy.
