### PR TITLE
Add option to fullscreen on start

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -58,7 +58,7 @@ const DefaultConfig: any = {
     //
     // IE, Windows:
     // "editor.quickOpen.execCommand": "dir /s /b"
-    "editor.fullScreenOnStart" : false
+    "editor.fullScreenOnStart" : false,
 }
 
 const MacConfig: any = {

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -24,7 +24,7 @@ const DefaultConfig: any = {
     // Production settings
 
     // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
-    // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config. 
+    // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
     //
     // Set this to 'false' to avoid loading the default config, and load settings from init.vim instead.
     "oni.useDefaultConfig": true,
@@ -58,6 +58,7 @@ const DefaultConfig: any = {
     //
     // IE, Windows:
     // "editor.quickOpen.execCommand": "dir /s /b"
+    "editor.fullScreenOnStart" : false
 }
 
 const MacConfig: any = {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -35,7 +35,6 @@ const start = (args: string[]) => {
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
     remote.BrowserWindow.getFocusedWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
-    // remote.BrowserWindow.getFocusedWindow().setFullScreen(true)
     require("./overlay.less")
 
     let deltaRegion = new IncrementalDeltaRegionTracker()

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -1,4 +1,4 @@
-import { ipcRenderer } from "electron"
+import { ipcRenderer, remote } from "electron"
 import * as minimist from "minimist"
 import * as path from "path"
 import * as Config from "./Config"
@@ -26,6 +26,7 @@ import { OverlayManager } from "./UI/Overlay/OverlayManager"
 import { ScrollBarOverlay } from "./UI/Overlay/ScrollBarOverlay"
 
 const start = (args: string[]) => {
+
     const services: any[] = []
 
     const parsedArgs = minimist(args)
@@ -33,7 +34,8 @@ const start = (args: string[]) => {
 
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
-
+    remote.BrowserWindow.getFocusedWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
+    // remote.BrowserWindow.getFocusedWindow().setFullScreen(true)
     require("./overlay.less")
 
     let deltaRegion = new IncrementalDeltaRegionTracker()


### PR DESCRIPTION
I *think* I rebased right...

Other than that, this just adds editor.fullScreenOnStart as a config option. From the BrowserWindow documentation, it seems like setting fullscreen as a **parameter** will have affect behavior, but as a method it just changes it harmlessly