### PR TITLE
Extr0py/205/incorporate react redux devtools

### DIFF
--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -192,7 +192,7 @@ export function showNeovimInstallHelp(): void {
     ReactDOM.render(<InstallHelp />, element)
 }
 
-const store = createStore(reducer, defaultState, window["__REDUX_DEVTOOLS_EXTENSION__"] && window["__REDUX_DEVTOOLS_EXTENSION__"]())
+const store = createStore(reducer, defaultState, window["__REDUX_DEVTOOLS_EXTENSION__"] && window["__REDUX_DEVTOOLS_EXTENSION__"]()) // tslint:disable-line no-string-literal
 
 export function init(): void {
     render(defaultState)

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -192,7 +192,7 @@ export function showNeovimInstallHelp(): void {
     ReactDOM.render(<InstallHelp />, element)
 }
 
-const store = createStore(reducer, defaultState)
+const store = createStore(reducer, defaultState, window["__REDUX_DEVTOOLS_EXTENSION__"] && window["__REDUX_DEVTOOLS_EXTENSION__"]())
 
 export function init(): void {
     render(defaultState)

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -34,7 +34,7 @@ const start = (args: string[]) => {
 
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
-    remote.BrowserWindow.getFocusedWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
+    remote.getCurrentWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
     require("./overlay.less")
 
     let deltaRegion = new IncrementalDeltaRegionTracker()

--- a/cli/oni
+++ b/cli/oni
@@ -28,4 +28,3 @@ child.unref()
 child.on("error", (err) => console.error(err))
 child.on("exit", (code) => process.exit(code));
 
-process.exit(0)

--- a/cli/oni
+++ b/cli/oni
@@ -28,3 +28,4 @@ child.unref()
 child.on("error", (err) => console.error(err))
 child.on("exit", (code) => process.exit(code));
 
+process.exit(0)

--- a/installDevTools.js
+++ b/installDevTools.js
@@ -1,0 +1,9 @@
+const electronDevtoolsInstaller = require("electron-devtools-installer")
+
+electronDevtoolsInstaller.default(electronDevtoolsInstaller.REACT_DEVELOPER_TOOLS)
+    .then((name) => console.log(`Added extension: ${name}`))
+    .catch((err) => console.log(`An error occurred: ${err}`))
+
+electronDevtoolsInstaller.default(electronDevtoolsInstaller.REDUX_DEVTOOLS)
+    .then((name) => console.log(`Added extension: ${name}`))
+    .catch((err) => console.log(`An error occurred: ${err}`))

--- a/installDevTools.js
+++ b/installDevTools.js
@@ -1,9 +1,19 @@
-const electronDevtoolsInstaller = require("electron-devtools-installer")
+/**
+ * installDevTools.js
+ *
+ * Helper to install the redux & react devtools
+ */
 
-electronDevtoolsInstaller.default(electronDevtoolsInstaller.REACT_DEVELOPER_TOOLS)
-    .then((name) => console.log(`Added extension: ${name}`))
-    .catch((err) => console.log(`An error occurred: ${err}`))
+try {
+    const electronDevtoolsInstaller = require("electron-devtools-installer")
+    electronDevtoolsInstaller.default(electronDevtoolsInstaller.REACT_DEVELOPER_TOOLS)
+        .then((name) => console.log(`Added extension: ${name}`))
+        .catch((err) => console.log(`An error occurred: ${err}`))
 
-electronDevtoolsInstaller.default(electronDevtoolsInstaller.REDUX_DEVTOOLS)
-    .then((name) => console.log(`Added extension: ${name}`))
-    .catch((err) => console.log(`An error occurred: ${err}`))
+    electronDevtoolsInstaller.default(electronDevtoolsInstaller.REDUX_DEVTOOLS)
+        .then((name) => console.log(`Added extension: ${name}`))
+        .catch((err) => console.log(`An error occurred: ${err}`))
+} catch (ex) {
+    console.warn("Unable to install developer tools. `electron-devtools-installer` may not be available in this environment")
+}
+

--- a/main.js
+++ b/main.js
@@ -7,12 +7,20 @@ const os = require('os');
 
 const ipcMain = electron.ipcMain
 
+const isDevelopment = process.env.NODE_ENV === "development" 
+
 const isVerbose = process.argv.filter(arg => arg.indexOf("--verbose") >= 0).length > 0
+const isDebug = process.argv.filter(arg => arg.indexOf("--debug") >= 0).length >0
+
+// import * as derp from "./installDevTools"
+
+if (isDebug || isDevelopment) {
+    require("./installDevTools")
+}
 
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
 const webContents = electron.webContents
-
 
 ipcMain.on("cross-browser-ipc", (event, arg) => {
     const destinationId = arg.meta.destinationId
@@ -38,7 +46,7 @@ let windows = []
 
 // Only enable 'single-instance' mode when we're not in the hot-reload mode
 // Otherwise, all other open instances will also pick up the webpack bundle
-if (process.env.NODE_ENV !== "development") {
+if (!isDevelopment && !isDebug) {
     const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
         createWindow(commandLine.slice(2), workingDirectory)
     })

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "2.2.5",
-    "electron": "1.4.12",
+    "electron": "1.4.15",
     "electron-default-menu": "1.0.0",
     "find-parent-dir": "0.3.0",
     "lodash": "4.17.0",
@@ -84,6 +84,7 @@
     "crlf": "1.1.0",
     "cross-env": "3.1.3",
     "css-loader": "0.26.1",
+    "electron-devtools-installer": "2.1.0",
     "jsdom": "9.9.1",
     "less": "2.7.1",
     "less-loader": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "2.2.5",
-    "electron": "1.4.15",
+    "electron": "1.4.12",
     "electron-default-menu": "1.0.0",
     "find-parent-dir": "0.3.0",
     "lodash": "4.17.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "classnames": "^2.2.5",
+    "classnames": "2.2.5",
     "electron": "1.4.12",
     "electron-default-menu": "1.0.0",
     "find-parent-dir": "0.3.0",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/classnames": "0.0.32",
     "@types/electron": "1.4.27",
-    "@types/jsdom": "^2.0.29",
+    "@types/jsdom": "2.0.29",
     "@types/lodash": "4.14.38",
     "@types/minimist": "1.1.29",
     "@types/mkdirp": "0.3.29",
@@ -84,7 +84,7 @@
     "crlf": "1.1.0",
     "cross-env": "3.1.3",
     "css-loader": "0.26.1",
-    "jsdom": "^9.9.1",
+    "jsdom": "9.9.1",
     "less": "2.7.1",
     "less-loader": "2.2.3",
     "less-plugin-autoprefix": "1.5.1",


### PR DESCRIPTION
Installs the [redux devtools](https://github.com/zalmoxisus/redux-devtools-extension) when running via either `oni --debug` or via `npm run start`. This is really helpful for understanding and debugging the UI functionality, and offers things like time travel debugging or going back to past history of the app. It also helps in terms of understanding the flow of actions and how they change the app state.