### PR TITLE
Fix #207 - Add the active window dimensions to the store

### DIFF
--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -23,7 +23,7 @@ export const setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixe
 
 export const setActiveWindowDimensions = (dimensions: Rectangle) => ({
     type: "SET_ACTIVE_WINDOW_DIMENSIONS",
-    payload: { dimensions }
+    payload: { dimensions },
 })
 
 export const setMode = (mode: string) => ({

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -1,3 +1,14 @@
+/**
+ * ActionCreators.ts
+ *
+ * Action Creators are relatively simple - they are just a function that returns an `Action`
+ *
+ * For information on Action Creators, check out this link:
+ * http://redux.js.org/docs/basics/Actions.html
+ */
+
+import { Rectangle } from "./Types"
+
 export const setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
     type: "SET_CURSOR_POSITION",
     payload: {
@@ -8,6 +19,11 @@ export const setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixe
         cursorCharacter,
         cursorPixelWidth,
     },
+})
+
+export const setActiveWindowDimensions = (dimensions: Rectangle) => ({
+    type: "SET_ACTIVE_WINDOW_DIMENSIONS",
+    payload: { dimensions }
 })
 
 export const setMode = (mode: string) => ({

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -1,3 +1,11 @@
+/**
+ * Action.ts
+ *
+ * Actions are simple payloads of information that send data from oni to the redux store.
+ *
+ * For information on Actions, check out this link:
+ * http://redux.js.org/docs/basics/Actions.html
+ */
 
 import { Rectangle } from "./Types"
 

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -1,3 +1,6 @@
+
+import { Rectangle } from "./Types"
+
 export interface ISetCursorPositionAction {
     type: "SET_CURSOR_POSITION",
     payload: {
@@ -7,6 +10,13 @@ export interface ISetCursorPositionAction {
         fontPixelHeight: number,
         cursorCharacter: string,
         cursorPixelWidth: number,
+    }
+}
+
+export interface ISetActiveWindowDimensions {
+    type: "SET_ACTIVE_WINDOW_DIMENSIONS",
+    payload: {
+        dimensions: Rectangle,
     }
 }
 
@@ -115,4 +125,5 @@ export type Action = ISetCursorPositionAction |
     INextMenuAction |
     IFilterMenuAction |
     ISetModeAction |
-    ISetColorsAction
+    ISetColorsAction |
+    ISetActiveWindowDimensions

--- a/browser/src/UI/Overlay/OverlayManager.ts
+++ b/browser/src/UI/Overlay/OverlayManager.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events"
+
 import * as _ from "lodash"
 
 import { IWindow } from "./../../neovim/Window"
@@ -14,7 +16,7 @@ interface IOverlayInfo {
     element: HTMLElement
 }
 
-export class OverlayManager {
+export class OverlayManager extends EventEmitter {
 
     private _screen: IScreen
     private _containerElement: HTMLElement
@@ -26,6 +28,8 @@ export class OverlayManager {
     private _neovimInstance: NeovimInstance
 
     constructor(screen: IScreen, neovimInstance: NeovimInstance) {
+        super()
+
         this._screen = screen
 
         const div = document.createElement("div")
@@ -93,6 +97,7 @@ export class OverlayManager {
                     overlayInfo.overlay.update(overlayInfo.element, windowContext)
                 })
 
+                this.emit("current-window-size-changed", dimensions)
             })
     }
 }

--- a/browser/src/UI/Overlay/OverlayManager.ts
+++ b/browser/src/UI/Overlay/OverlayManager.ts
@@ -82,11 +82,18 @@ export class OverlayManager extends EventEmitter {
                 const windowStartRow = dimensions.row
                 const windowStartColumn = dimensions.col
 
-                this._containerElement.style.top = (windowStartRow * this._screen.fontHeightInPixels) + "px"
-                this._containerElement.style.left = (windowStartColumn * this._screen.fontWidthInPixels) + "px"
+                const dimensionsInPixels = {
+                    x: windowStartColumn * this._screen.fontWidthInPixels,
+                    y: windowStartRow * this._screen.fontHeightInPixels,
+                    width: dimensions.width * this._screen.fontWidthInPixels,
+                    height: dimensions.height * this._screen.fontHeightInPixels,
+                }
 
-                const width = (dimensions.width * this._screen.fontWidthInPixels) + "px"
-                const height = (dimensions.height * this._screen.fontHeightInPixels) + "px"
+                this._containerElement.style.top = (dimensionsInPixels.y) + "px"
+                this._containerElement.style.left = (dimensionsInPixels.x) + "px"
+
+                const width = (dimensionsInPixels.width) + "px"
+                const height = (dimensionsInPixels.height) + "px"
 
                 this._containerElement.style.width = width
                 this._containerElement.style.height = height
@@ -97,7 +104,7 @@ export class OverlayManager extends EventEmitter {
                     overlayInfo.overlay.update(overlayInfo.element, windowContext)
                 })
 
-                this.emit("current-window-size-changed", dimensions)
+                this.emit("current-window-size-changed", dimensionsInPixels)
             })
     }
 }

--- a/browser/src/UI/Overlay/WindowContext.ts
+++ b/browser/src/UI/Overlay/WindowContext.ts
@@ -1,13 +1,7 @@
 
-import { IWindowDimensions } from "./../../neovim/Window"
+import { Rectangle } from "./../Types"
 
-// TODO: Can these types be consolidated?
-export interface IPixelRectangle {
-    x: number
-    y: number
-    width: number
-    height: number
-}
+import { IWindowDimensions } from "./../../neovim/Window"
 
 /**
  * These interfaces must be kept in sync with the window_display_update method in init.vim
@@ -83,7 +77,7 @@ export class WindowContext {
         }
     }
 
-    public getWindowPosition(line: number, column: number): IPixelRectangle {
+    public getWindowPosition(line: number, column: number): Rectangle {
         const linePosition = this.getWindowRegionForLine(line)
         const columnPosition = (this._eventContext.wincol - this._eventContext.column + column - 1) * this._fontWidthInPixels
         return {

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -20,6 +20,8 @@ export const reducer = (s: State.IState, a: Actions.Action) => {
                 cursorCharacter: a.payload.cursorCharacter,
                 cursorPixelWidth: a.payload.cursorPixelWidth,
             })
+        case "SET_ACTIVE_WINDOW_DIMENSIONS":
+            return { ...s, ...{ activeWindowDimensions: a.payload.dimensions } }
         case "SET_MODE":
             return { ...s, ...{ mode: a.payload.mode } }
         case "SET_COLORS":

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -15,7 +15,8 @@ export interface IState {
     popupMenu: null | IMenu
     signatureHelp: null | Oni.Plugin.SignatureHelpResult
 
-    activeWindowSize: null | Rectangle
+    // Dimensions of active window, in pixels
+    activeWindowDimensions: null | Rectangle
 }
 
 export interface IMenu {
@@ -59,5 +60,5 @@ export const createDefaultState = () => ({
     quickInfo: null,
     popupMenu: null,
     signatureHelp: null,
-    activeWindowSize: null,
+    activeWindowDimensions: null,
 })

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -1,3 +1,6 @@
+
+import { Rectangle } from "./Types"
+
 export interface IState {
     cursorPixelX: number
     cursorPixelY: number
@@ -11,6 +14,8 @@ export interface IState {
     quickInfo: null | Oni.Plugin.QuickInfo
     popupMenu: null | IMenu
     signatureHelp: null | Oni.Plugin.SignatureHelpResult
+
+    activeWindowSize: null | Rectangle
 }
 
 export interface IMenu {

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -45,3 +45,19 @@ export interface IAutoCompletionInfo {
      */
     selectedIndex: number
 }
+
+export const createDefaultState = () => ({
+    cursorPixelX: 10,
+    cursorPixelY: 10,
+    cursorPixelWidth: 10,
+    cursorCharacter: "",
+    fontPixelWidth: 10,
+    fontPixelHeight: 10,
+    mode: "normal",
+    foregroundColor: "rgba(0, 0, 0, 0)",
+    autoCompletion: null,
+    quickInfo: null,
+    popupMenu: null,
+    signatureHelp: null,
+    activeWindowSize: null,
+})

--- a/browser/src/UI/Types.ts
+++ b/browser/src/UI/Types.ts
@@ -1,0 +1,6 @@
+export interface Rectangle {
+    x: number
+    y: number
+    width: number
+    height: number
+}

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -33,7 +33,7 @@ let defaultState: State.IState = {
     quickInfo: null,
     popupMenu: null,
     signatureHelp: null,
-    activeWindowSize: null
+    activeWindowSize: null,
 }
 
 const CompletionItemSelectedEvent = "completion-item-selected"

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -33,6 +33,7 @@ let defaultState: State.IState = {
     quickInfo: null,
     popupMenu: null,
     signatureHelp: null,
+    activeWindowSize: null
 }
 
 const CompletionItemSelectedEvent = "completion-item-selected"

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -20,21 +20,7 @@ import { IScreen } from "./../Screen"
 
 export const events = new EventEmitter()
 
-let defaultState: State.IState = {
-    cursorPixelX: 10,
-    cursorPixelY: 10,
-    cursorPixelWidth: 10,
-    cursorCharacter: "",
-    fontPixelWidth: 10,
-    fontPixelHeight: 10,
-    mode: "normal",
-    foregroundColor: "rgba(0, 0, 0, 0)",
-    autoCompletion: null,
-    quickInfo: null,
-    popupMenu: null,
-    signatureHelp: null,
-    activeWindowSize: null,
-}
+let defaultState = State.createDefaultState()
 
 const CompletionItemSelectedEvent = "completion-item-selected"
 

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -9,6 +9,7 @@ import * as Config from "./../Config"
 
 import { RootComponent } from "./RootComponent"
 import * as State from "./State"
+import { Rectangle } from "./Types"
 
 // import * as Actions from "./Actions"
 import * as ActionCreators from "./ActionCreators"
@@ -34,6 +35,11 @@ export function setBackgroundColor(backgroundColor: string): void {
     backgroundImageElement.style.backgroundSize = backgroundImageSize
     backgroundColorElement.style.backgroundColor = backgroundColor
     backgroundColorElement.style.opacity = Config.getValue<string>("prototype.editor.backgroundOpacity")
+}
+
+// TODO: Can we use bindaction creators for this?
+export function setActiveWindowDimensionsChanged(dimensions: Rectangle) {
+    store.dispatch(ActionCreators.setActiveWindowDimensions(dimensions))
 }
 
 export function setCursorPosition(screen: IScreen): void {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -7,7 +7,6 @@ import { Keyboard } from "./Input/Keyboard"
 import { Mouse } from "./Input/Mouse"
 import { NeovimInstance } from "./NeovimInstance"
 import { PluginManager } from "./Plugins/PluginManager"
-// import { CanvasRenderer } from "./Renderer/CanvasRenderer"
 import { DOMRenderer } from "./Renderer/DOMRenderer"
 import { NeovimScreen } from "./Screen"
 import { Errors } from "./Services/Errors"
@@ -24,6 +23,7 @@ import { ErrorOverlay } from "./UI/Overlay/ErrorOverlay"
 import { LiveEvaluationOverlay } from "./UI/Overlay/LiveEvaluationOverlay"
 import { OverlayManager } from "./UI/Overlay/OverlayManager"
 import { ScrollBarOverlay } from "./UI/Overlay/ScrollBarOverlay"
+import { Rectangle } from "./UI/Types"
 
 const start = (args: string[]) => {
 
@@ -80,6 +80,8 @@ const start = (args: string[]) => {
     overlayManager.addOverlay("errors", errorOverlay)
     overlayManager.addOverlay("live-eval", liveEvaluationOverlay)
     overlayManager.addOverlay("scrollbar", scrollbarOverlay)
+
+    overlayManager.on("current-window-size-changed", (dimensionsInPixels: Rectangle) => UI.setActiveWindowDimensionsChanged(dimensionsInPixels))
 
     pluginManager.on("signature-help-response", (err: string, signatureHelp: any) => { // FIXME: setup Oni import
         if (err) {

--- a/browser/tslint.json
+++ b/browser/tslint.json
@@ -14,6 +14,9 @@
       true,
       "never"
     ],
+    "interface-name": [
+        false,
+    ],
     "variable-name": [
       true,
       "allow-leading-underscore",

--- a/browser/tslint.json
+++ b/browser/tslint.json
@@ -15,7 +15,7 @@
       "never"
     ],
     "interface-name": [
-        false,
+        false
     ],
     "variable-name": [
       true,


### PR DESCRIPTION
This wires up the active window tracking that lives in `OverlayManager` to our redux store, so that it is accessible to the UI components.

This adds the `SET_ACTIVE_WINDOW_DIMENSIONS` action and adds a state object `activeWindowDimensions` so the `cursorline`/`cursorcolumn` work can pick that up.

Here's what it looks like in the redux dev tools:
![image](https://cloud.githubusercontent.com/assets/13532591/22856316/ddcf0a40-f043-11e6-9d90-ac8ffb569e00.png)
