### PR TITLE
Prevented default on all modifier keys (temporary fix for 216)

### DIFF
--- a/browser/src/Input/Keyboard.ts
+++ b/browser/src/Input/Keyboard.ts
@@ -19,9 +19,6 @@ export class Keyboard extends EventEmitter {
             // so we need to stop that.
             //
             // Later, the menu should be customized to fix this.
-            if (mappedKey === "<C-w>" || mappedKey === "<C-r>") {
-                evt.preventDefault()
-            }
         })
     }
 
@@ -38,10 +35,16 @@ export class Keyboard extends EventEmitter {
 
         if (evt.ctrlKey) {
             mappedKey = "C-" + vimKey + ""
+            evt.preventDefault()
         }
 
         if (evt.altKey) {
             mappedKey = "A-" + mappedKey
+            evt.preventDefault()
+        }
+
+        if (evt.metaKey) {
+            evt.preventDefault()
         }
 
         if (mappedKey.length > 1) {
@@ -54,16 +57,16 @@ export class Keyboard extends EventEmitter {
     private _convertKeyEventToVimKey(evt: KeyboardEvent): null | string {
 
        const keyCode = {
-             8:  "bs",      // Backspace                 
-             9:  "tab",     // Tab                 
-             13: "enter",   // Enter                 
+             8:  "bs",      // Backspace
+             9:  "tab",     // Tab
+             13: "enter",   // Enter
              27: "esc",     // Escape
              33: "pageup",  // Page up
              34: "pagedown", // Page down
              35: "end",
              36: "home",
              37: "left",    // ArrowLeft
-             38: "up",      // ArrowUp 
+             38: "up",      // ArrowUp
              39: "right",   // ArrowRight
              40: "down",    // ArrowDown
              45: "insert",
@@ -77,7 +80,7 @@ export class Keyboard extends EventEmitter {
              20:  null,     // Caps lock
              145: null,     // Scroll lock
              174: null,     // Volume up
-             175: null,     // Volume down                
+             175: null,     // Volume down
         }
 
        return keyCode[evt.keyCode ] ? keyCode[evt.keyCode ] : evt.key


### PR DESCRIPTION
This is a temporary fix, but I think it's in the right direction for #216. Odds are we're going to only be whitelisting keys based on config, everything else should be blocked. This fixed command-a select for me and made ctrl-r work

Also this was an excuse to get rid of some gross whitespace