### PR TITLE
Tweak some menu labels

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,13 +188,13 @@ function createWindow(commandLineArguments, workingDirectory) {
            }
        },
        {
-           label: 'Put Before',
+           label: 'Paste Line Before',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", "[p")
            }
        },
        {
-           label: 'Put After',
+           label: 'Paste Line After',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", "]p")
            }
@@ -208,27 +208,28 @@ function createWindow(commandLineArguments, workingDirectory) {
     ]
 
     // Window menu
+    menu[3].label = 'Split'
     menu[3].submenu = [
         {
-           label: 'New',
+           label: 'New Horizontal Split',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", "\\<C-w>n")
            }
         },
         {
-           label: 'Split',
+           label: 'Split File Horizontally',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", "\\<C-w>s")
            }
         },
         {
-           label: 'Split Vertically',
+           label: 'Split File Vertically',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", "\\<C-w>v")
            }
         },
         {
-           label: 'Split File Explorer',
+           label: 'File Explorer Split',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", ":Lexplore | vertical resize 30")
            }
@@ -243,13 +244,41 @@ function createWindow(commandLineArguments, workingDirectory) {
            }
         },
         {
-           label: 'Close Other(s)',
+           label: 'Close Other Split(s)',
            click: (item, focusedWindow) => {
                mainWindow.webContents.send("menu-item-click", "\\<C-w>o")
            }
         },
         {
             type: 'separator'
+        },
+        {
+           label: 'Move To',
+           submenu: [
+           {
+                label: 'Top',
+                click: (item, focusedWindow) => {
+                    mainWindow.webContents.send("menu-item-click", "\\<C-w>K")
+                }
+            },
+            {
+                label: 'Bottom',
+                click: (item, focusedWindow) => {
+                    mainWindow.webContents.send("menu-item-click", "\\<C-w>J")
+                }
+            },
+            {
+                label: 'Left Side',
+                click: (item, focusedWindow) => {
+                    mainWindow.webContents.send("menu-item-click", "\\<C-w>H")
+                }
+            },
+            {
+                label: 'Right Side',
+                click: (item, focusedWindow) => {
+                    mainWindow.webContents.send("menu-item-click", "\\<C-w>L")
+                }
+            }]
         },
         {
            label: 'Rotate Up',


### PR DESCRIPTION
extr0py made a comment when I created the Window menu that these menus are good for people getting started with Vim.  That got me thinking about how some of these menu labels are really obtuse.  Even after executing some of them I couldn't tell the difference between some options.  So I decided to change the labels to be more explanatory.  Rather than "New" and "Split" it's "New Horizontal Split" and "Split File Horizontally".  Also, the menu was called "Window" when all of the operations affect splits.  So I changed it to "Split".  I think this makes it more intuitive.  `Split -> New Horizontal Split` makes much more sense to me than `Window -> New`.  I kept wondering if `Window -> New` was supposed to be creating a new window until I tried it in GVim and found that no, it really does just create an empty split.

Oh, I also added the `Move To` sub-menu which I missed last time.  So I guess this Pull Request isn't purely superficial.