### PR TITLE
Extr0py/use new cursorline

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -60,7 +60,7 @@ const DefaultConfig: any = {
     // "editor.quickOpen.execCommand": "dir /s /b"
     "editor.fullScreenOnStart" : false,
 
-    "editor.cursorLine": false,
+    "editor.cursorLine": true,
     "editor.cursorColumn": false,
 }
 

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -13,8 +13,9 @@ import { IWindow, Window } from "./neovim/Window"
 import * as Platform from "./Platform"
 import { PluginManager } from "./Plugins/PluginManager"
 import { IPixelPosition, IPosition } from "./Screen"
+import { nodeRequire } from "./Utility"
 
-const attach = require("neovim-client") // tslint:disable-line no-var-requires
+const attach = nodeRequire("neovim-client")
 
 export interface INeovimInstance {
     cursorPosition: IPosition

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility.ts
+ *
+ * Grab bag for functions that don't have another home. 
+ */
+
+/**
+ * Use a `node` require instead of a `webpack` require
+ * The difference is that `webpack` require will bake the javascript
+ * into the module. For most modules, we want the webpack behavior,
+ * but for some (like node modules), we want to explicitly require them.
+ */
+export function nodeRequire(moduleName: string): any {
+    return window["require"](moduleName) // tslint:disable-line
+}

--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -2,7 +2,6 @@ set number
 set relativenumber
 set noswapfile
 set ruler
-set cursorline
 set smartcase
 
 set splitright


### PR DESCRIPTION
Use the new cursorline implemented by @bert88sta and remove from the vimrc. Since `cursorline` can be slow, this can improve performance (it decreases churn over `msgpack-rpc` in the general case)