### PR TITLE
Update to use new cursorline

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -60,7 +60,7 @@ const DefaultConfig: any = {
     // "editor.quickOpen.execCommand": "dir /s /b"
     "editor.fullScreenOnStart" : false,
 
-    "editor.cursorLine": false,
+    "editor.cursorLine": true,
     "editor.cursorColumn": false,
 }
 

--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -2,7 +2,6 @@ set number
 set relativenumber
 set noswapfile
 set ruler
-set cursorline
 set smartcase
 
 set splitright


### PR DESCRIPTION
Use the new cursorline implemented by @bert88sta and remove from the vimrc. Since cursorline can be slow, this can improve performance (it decreases churn over msgpack-rpc in the general case)