### PR TITLE
Add nodeRequire utility

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -13,8 +13,9 @@ import { IWindow, Window } from "./neovim/Window"
 import * as Platform from "./Platform"
 import { PluginManager } from "./Plugins/PluginManager"
 import { IPixelPosition, IPosition } from "./Screen"
+import { nodeRequire } from "./Utility"
 
-const attach = require("neovim-client") // tslint:disable-line no-var-requires
+const attach = nodeRequire("neovim-client")
 
 export interface INeovimInstance {
     cursorPosition: IPosition

--- a/browser/src/Utility.ts
+++ b/browser/src/Utility.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility.ts
+ *
+ * Grab bag for functions that don't have another home. 
+ */
+
+/**
+ * Use a `node` require instead of a `webpack` require
+ * The difference is that `webpack` require will bake the javascript
+ * into the module. For most modules, we want the webpack behavior,
+ * but for some (like node modules), we want to explicitly require them.
+ */
+export function nodeRequire(moduleName: string): any {
+    return window["require"](moduleName) // tslint:disable-line
+}


### PR DESCRIPTION
Add a quick utility to a node-style require as opposed to the webpack-style require (which is default). For stuff in browser/src, anything with the normal `require` gets included in the script. This can slow down loading, so the `nodeRequire` uses a node-style require.