### PR TITLE
Start formalizing commands

### DIFF
--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -63,8 +63,11 @@ export class PluginManager extends EventEmitter {
 
     public executeCommand(command: string): void {
         if (command === "editor.gotoDefinition") {
-            this._sendLanguageServiceRequest("goto-definition", this._lastEventContext)
         }
+    }
+
+    public gotoDefinition(): void {
+        this._sendLanguageServiceRequest("goto-definition", this._lastEventContext)
     }
 
     public requestFormat(): void {

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -61,11 +61,6 @@ export class PluginManager extends EventEmitter {
         return this._lastBufferInfo
     }
 
-    public executeCommand(command: string): void {
-        if (command === "editor.gotoDefinition") {
-        }
-    }
-
     public gotoDefinition(): void {
         this._sendLanguageServiceRequest("goto-definition", this._lastEventContext)
     }

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -1,0 +1,79 @@
+/**
+ * CommandManager.ts
+ *
+ * Manages Oni commands. These commands show up in the command palette, and are exposed to plugins.
+ */
+
+import * as _ from "lodash"
+import * as Q from "q"
+
+import { INeovimInstance } from "./../NeovimInstance"
+
+import { ITask, ITaskProvider } from "./Tasks"
+
+
+export interface ICommand {
+    command: string
+    name: string
+    detail: string
+    execute: (args?: any) => void
+}
+
+export class CallbackCommand implements ICommand {
+    constructor(
+        public command: string,
+        public name: string,
+        public detail: string,
+        public execute: (args?: any) => void) { }
+}
+
+export class VimCommand implements ICommand {
+
+    constructor(
+        public command: string,
+        public name: string, public detail: string,
+        private _vimCommand: string,
+        private _neovimInstance: INeovimInstance) {
+
+    }
+
+    public execute(): void {
+        this._neovimInstance.command(this._vimCommand)
+    }
+}
+
+export class CommandManager implements ITaskProvider {
+
+    private _commandDictionary: { [key: string]: ICommand } = {}
+
+    public registerCommand(command: ICommand): void {
+
+        if (this._commandDictionary[command.name]) {
+            console.error(`Tried to register multiple commands for: ${command.name}`)
+            return
+        }
+
+        this._commandDictionary[command.name] = command
+    }
+
+    public executeCommand(name: string, args: any): void {
+        const command = this._commandDictionary[name]
+
+        if (!command) {
+            console.error(`Unable to find command: ${name}`)
+            return
+        }
+
+        command.execute(args)
+    }
+
+    public getTasks(): Q.Promise<ITask[]> {
+        const commands = _.values(this._commandDictionary)
+        const tasks = commands.map((c) => ({
+            name: c.name,
+            detail: c.detail,
+            callback: () => c.execute(),
+        })
+        return Q(tasks)
+    }
+}

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -11,7 +11,6 @@ import { INeovimInstance } from "./../NeovimInstance"
 
 import { ITask, ITaskProvider } from "./Tasks"
 
-
 export interface ICommand {
     command: string
     name: string
@@ -48,12 +47,12 @@ export class CommandManager implements ITaskProvider {
 
     public registerCommand(command: ICommand): void {
 
-        if (this._commandDictionary[command.name]) {
+        if (this._commandDictionary[command.command]) {
             console.error(`Tried to register multiple commands for: ${command.name}`)
             return
         }
 
-        this._commandDictionary[command.name] = command
+        this._commandDictionary[command.command] = command
     }
 
     public executeCommand(name: string, args: any): void {
@@ -73,7 +72,7 @@ export class CommandManager implements ITaskProvider {
             name: c.name,
             detail: c.detail,
             callback: () => c.execute(),
-        })
+        }))
         return Q(tasks)
     }
 }

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -1,0 +1,27 @@
+/**
+ * Commands.ts
+ *
+ * Built-in Oni Commands
+ */
+
+import { remote } from "electron"
+
+import { PluginManager } from "./../Plugins/PluginManager"
+
+import { CallbackCommand, CommandManager } from "./CommandManager"
+
+export const registerBuiltInCommands = (commandManager: CommandManager, pluginManager: PluginManager) => {
+    const commands = [
+
+        // Debug
+        new CallbackCommand("oni.debug.openDevTools", "Open DevTools", "Debug ONI and any running plugins using the Chrome developer tools", () => remote.getCurrentWindow().webContents.openDevTools()),
+
+        // Language service
+        new CallbackCommand("oni.editor.gotoDefinition", "Goto Definition", "Goto definition using a language service", () => pluginManager.gotoDefinition())
+
+        // Add additional commands here
+        // ...
+    ]
+
+    commands.forEach((c) => commandManager.registerCommand(c))
+}

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -17,7 +17,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         new CallbackCommand("oni.debug.openDevTools", "Open DevTools", "Debug ONI and any running plugins using the Chrome developer tools", () => remote.getCurrentWindow().webContents.openDevTools()),
 
         // Language service
-        new CallbackCommand("oni.editor.gotoDefinition", "Goto Definition", "Goto definition using a language service", () => pluginManager.gotoDefinition())
+        new CallbackCommand("oni.editor.gotoDefinition", "Goto Definition", "Goto definition using a language service", () => pluginManager.gotoDefinition()),
 
         // Add additional commands here
         // ...

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -9,6 +9,8 @@ import { NeovimInstance } from "./NeovimInstance"
 import { PluginManager } from "./Plugins/PluginManager"
 import { DOMRenderer } from "./Renderer/DOMRenderer"
 import { NeovimScreen } from "./Screen"
+import { CommandManager } from "./Services/CommandManager"
+import { registerBuiltInCommands } from "./Services/Commands"
 import { Errors } from "./Services/Errors"
 import { Formatter } from "./Services/Formatter"
 import { LiveEvaluation } from "./Services/LiveEvaluation"
@@ -57,8 +59,6 @@ const start = (args: string[]) => {
     let renderer = new DOMRenderer()
     renderer.start(editorElement)
 
-
-
     let pendingTimeout: any = null
 
     // Services
@@ -71,7 +71,10 @@ const start = (args: string[]) => {
     const liveEvaluation = new LiveEvaluation(instance, pluginManager)
     const syntaxHighlighter = new SyntaxHighlighter(instance, pluginManager)
     const tasks = new Tasks(outputWindow)
+    const commandManager = new CommandManager()
+    registerBuiltInCommands(commandManager, pluginManager)
 
+    tasks.registerTaskProvider(commandManager)
     tasks.registerTaskProvider(errorService)
 
     services.push(errorService)
@@ -290,7 +293,7 @@ const start = (args: string[]) => {
         }
 
         if (key === "<f12>") {
-            pluginManager.executeCommand("editor.gotoDefinition")
+            commandManager.executeCommand("oni.editor.gotoDefinition", null)
         } else if (key === "<C-p>" && screen.mode === "normal") {
             quickOpen.show()
         } else if (key === "<C-P>" && screen.mode === "normal") {


### PR DESCRIPTION
This change implements a `CommandManager` - this is intended to be the central point to register commands. Commands can come from a variety of sources:
- Plugins will be able to register commands in the package.json
- There will be built-in commands (ie, language service stuff like goto definition, showing errors)
- VIM commands (like split etc) would also be nice to have here - we can add additional helper text and information.