### PR TITLE
Fix #241 - Remove `config.json` [BREAKING CHANGE]

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ Leave the cursor hovering over an identifier.
 
 ### Configuration
 
-> ONI is configurable via a 'config.json' located in $HOME/.oni
+> ONI is configurable via a 'config.js' located in $HOME/.oni
 
-Here's an example config.json:
+Here's an example config.js:
 ```
-{
+module.exports = {
     "oni.useDefaultConfig": true,
     "oni.loadInitVim": true,
     "editor.fontSize": "14px",

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -80,15 +80,11 @@ const DefaultPlatformConfig = Platform.isWindows() ? WindowsConfig : Platform.is
 
 Performance.mark("Config.load.start")
 
-export const userConfigFile = path.join(getUserFolder(), "config.json")
 export const userJsConfig = path.join(getUserFolder(), "config.js")
 
 let userConfig = {}
-if (fs.existsSync(userConfigFile)) {
-    userConfig = JSON.parse(fs.readFileSync(userConfigFile, "utf8"))
-}
-
 let userRuntimeConfig = {}
+
 if (fs.existsSync(userJsConfig)) {
     userRuntimeConfig = global["require"](userJsConfig) // tslint:disable-line no-string-literal
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oni-vim",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "NeoVim front-end with IDE-style extensibility",
   "keywords": [
     "vim",


### PR DESCRIPTION
Right now, our configuration story is extra-confusing because we support two types of Oni extensions - `config.js` and `config.json`. The `config.js` is more flexible, as it can be easily programmatically extended, so this is what we'll move forward with.

However, this is a __BREAKING CHANGE__ for anyone that has configuration in `config.json`.

The following steps will be needed:
- Rename `config.json` to `config.js`
- Change the top curly brace `{` to `module.exports = {`

Once that is done, Oni should work as expected