### PR TITLE
Add config for debugging Oni in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Debug files that configure Electron (main.js, Menu.js, etc.)
+            "name": "Oni Main Process",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/main.js",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "runtimeArgs": [
+                "--enable-logging"
+            ],
+            "console": "internalConsole"
+        },
+        {
+            // Debug typescript files
+            // (must run `npm run build-debug` first to generate bundle.js.map)
+            "name": "Oni Application",
+            "type": "chrome", // <-- requires Extension "Debugger for Chrome"
+            "request": "launch",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "runtimeArgs": [
+                "--enable-logging",
+                "${workspaceRoot}/main.js"
+            ],
+            "webRoot": "${workspaceRoot}",
+            "sourceMaps": true,
+            "sourceMapPathOverrides": {
+                "webpack:///./*": "${webRoot}/*"
+            }
+        }
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ In order to build a source-map enabled build, you can do the following:
 - `npm link` (only needed the first time)
 - `oni`
 
+Debugging in [VSCode](https://github.com/Microsoft/vscode)?  Default launch configurations are provided for debugging both the Electron main process and Oni application from VSCode.
+
 ## Production build
 
 A production build removes sourcemaps and applies minification, so it's worth testing in this config:


### PR DESCRIPTION
I created a configuration for debugging Oni from within VSCode.  It will allow you to set breakpoints in VSCode and use the debugger.  Personally, I like having a separate application for my code/debugger rather than trying to use the built-in Developer Tools from Chrome, and VSCode has good support for typescript.

With that said, if you're personally offended that I would suggest people use VSCode to develop Oni then I'll close this Pull Request. :smile:  I was just happy to finally get this to work so I figured I'd share it; it's no problem if you don't want this committed.