### PR TITLE
Fix #250, set menu per window on Windows and Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,7 +64,13 @@ function createWindow(commandLineArguments, workingDirectory) {
     let mainWindow = new BrowserWindow({ width: 800, height: 600, icon: path.join(__dirname, "images", "Oni_128.png") })
 
     const menu = buildMenu(mainWindow)
-    Menu.setApplicationMenu(menu);
+    if (process.platform === 'darwin') {
+        //all osx windows share the same menu
+        Menu.setApplicationMenu(menu)
+    } else {
+        //on windows and linux, set menu per window
+        mainWindow.setMenu(menu);
+    }
 
     mainWindow.webContents.on("did-finish-load", () => {
         mainWindow.webContents.send("init", {


### PR DESCRIPTION
`Menu.setApplicationMenu(menu)` is for use on macOS where all windows of an application share the same menu.
https://electron.atom.io/docs/api/menu/#menusetapplicationmenumenu

`BrowserWindow.setMenu(menu)` is for use on Windows and Linux where each window is given its own menu.
https://electron.atom.io/docs/api/browser-window/#winsetmenumenu-linux-windows

This fixes #250 for me on Linux but I don't have a Mac to test it on so I'll just assume the previous line still works as desired.  I don't know if #250 was ever an issue on Mac.