### PR TITLE
Fix #261: Remove writing to log file from process

### DIFF
--- a/cli/oni
+++ b/cli/oni
@@ -6,11 +6,8 @@ var os = require("os")
 var fs = require("fs")
 
 var processOptions = {}
-var log = require("path").join(__dirname, "out.log")
-var out = fs.openSync(log, "a")
-var err = fs.openSync(log, "a")
 processOptions.detached = true
-processOptions.stdio = ["ignore", out, err]
+processOptions.stdio = ["ignore", null, null]
 
 var isWindows = os.platform() === "win32";
 


### PR DESCRIPTION
Remove creating `out.log` when starting Oni - there isn't much interesting that goes in there, anyway.