### PR TITLE
Fix #252, create default config.js if one doesn't already exist

### DIFF
--- a/Menu.js
+++ b/Menu.js
@@ -62,11 +62,11 @@ const buildMenu = (mainWindow) => {
                 label: 'Preferences',
                 submenu: [
                 {
-                    label: "Edit configuration",
+                    label: "Edit Oni config",
                     click: () => executeOniCommand("oni.config.openConfigJs")
                 },
                 {
-                    label: "Edit Neovim configuration",
+                    label: "Edit Neovim config",
                     click: () => executeOniCommand("oni.config.openInitVim")
                 }
                 ]

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -7,6 +7,7 @@
 import { remote } from "electron"
 
 import * as Config from "./../Config"
+import { IBuffer } from "./../neovim/Buffer"
 import { INeovimInstance } from "./../NeovimInstance"
 import { PluginManager } from "./../Plugins/PluginManager"
 
@@ -22,9 +23,27 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         new CallbackCommand("oni.editor.gotoDefinition", "Goto Definition", "Goto definition using a language service", () => pluginManager.gotoDefinition()),
 
         // Menu commands
-        // TODO: Generate config.js if not already built
-        new CallbackCommand("oni.config.openConfigJs", "Edit Configuration", "Edit configuration file ('config.js') for ONI", () => neovimInstance.open(Config.userJsConfig)),
-        new CallbackCommand("oni.config.openInitVim", "Edit Neovim Configuration", "Edit configuration file ('init.vim') for Neovim", () => neovimInstance.open("$MYVIMRC")),
+        new CallbackCommand("oni.config.openConfigJs", "Edit Oni Config", "Edit configuration file ('config.js') for ONI", () => {
+            let buffer: null | IBuffer = null
+            neovimInstance.open(Config.userJsConfig)
+                .then(() => neovimInstance.getCurrentBuffer())
+                .then((buf) => buffer = buf)
+                .then(() => buffer.getLineCount())
+                .then((count) => {
+                    if (count === 1) {
+                        let lines = [
+                            "module.exports = {",
+                            "  //add custom config here, such as",
+                            "  //\"oni.useDefaultConfig\": true,",
+                            "  //\"editor.fontSize\": \"14px\",",
+                            "  //\"editor.fontFamily\": \"Monaco\"",
+                            "}",
+                        ]
+                        buffer.setLines(0, lines.length, false, lines)
+                    }
+                })
+        }),
+        new CallbackCommand("oni.config.openInitVim", "Edit Neovim Config", "Edit configuration file ('init.vim') for Neovim", () => neovimInstance.open("$MYVIMRC")),
 
         // Add additional commands here
         // ...


### PR DESCRIPTION
As I requested in #243, if the user selects `Edit Oni Config` from the Menu or Command Palette and the file doesn't already exist, create some default content showing the format.