### PR TITLE
use glob rather than recursive-readdir to fetch files in Fuzzy Finder

### DIFF
--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -44,7 +44,7 @@
             flex-direction: row;
             align-items: center;
 
-            .fa {
+            .fa:not(.fa-spin) {
                 padding-right: 8px;
             }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "electron": "1.4.12",
     "electron-default-menu": "1.0.0",
     "find-parent-dir": "0.3.0",
+    "glob": "7.1.1",
     "lodash": "4.17.0",
     "minimist": "1.2.0",
     "mkdirp": "0.5.1",
@@ -55,7 +56,6 @@
     "react-dom": "15.3.1",
     "react-measure": "1.4.2",
     "react-redux": "4.4.5",
-    "recursive-readdir": "2.1.0",
     "redux": "3.5.2",
     "typescript": "2.2.1",
     "wcwidth": "1.0.1"
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@types/classnames": "0.0.32",
     "@types/electron": "1.4.27",
+    "@types/glob": "5.0.30",
     "@types/jsdom": "2.0.29",
     "@types/lodash": "4.14.38",
     "@types/minimist": "1.1.29",
@@ -74,7 +75,6 @@
     "@types/react-dom": "0.14.18",
     "@types/react-measure": "0.4.5",
     "@types/react-redux": "4.4.32",
-    "@types/recursive-readdir": "1.2.28",
     "@types/sinon": "1.16.32",
     "autoprefixer": "6.4.0",
     "concurrently": "3.1.0",


### PR DESCRIPTION
This should fix #267, #177, and #125.  `recursive-readdir` has a known issue with broken symlinks but it doesn't look like that defect will ever be fixed.  Use the [node-glob](https://github.com/isaacs/node-glob) library instead.  This library ignores all hidden (`.*`) directories by default so I just added a default ignore of `node_modules` since that directory always has thousands of files in it.  We can tell it to include hidden directories and then explicitly exclude things like `.git`, `.svn`, `.Trash` if we want but I'm not sure if anyone would ever want to look inside hidden directories so this default seems sensible to me.

Also, I added an animated "loading files" indicator in case this takes a while.  The operation is pretty quick after I excluded `node_modules` but I'm sure there will still be still be users with large directories.