### PR TITLE
Fix #230: Upgrade to electron 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "2.2.5",
-    "electron": "1.4.12",
+    "electron": "1.6.1",
     "electron-default-menu": "1.0.0",
     "find-parent-dir": "0.3.0",
     "glob": "7.1.1",


### PR DESCRIPTION
- Upgrade to Electron 1.6.1

See release notes here: https://github.com/electron/electron/releases

Lots of big improvements on the Electron side - they've moved to Chrome 56 and v8 5.6, both of which have performance improvements. 