### PR TITLE
Fix #271 - Live-eval broken

### DIFF
--- a/browser/src/Plugins/Api/DebouncedLanguageService.ts
+++ b/browser/src/Plugins/Api/DebouncedLanguageService.ts
@@ -10,6 +10,8 @@ export class DebouncedLanguageService implements Oni.Plugin.LanguageService {
     private _debouncedFormattingEdits: PromiseFunction<null | Oni.Plugin.FormattingEditsResponse>
     private _debouncedGetSignatureHelp: PromiseFunction<null | Oni.Plugin.SignatureHelpResult>
     private _debouncedQuickInfo: PromiseFunction<null | Oni.Plugin.QuickInfo>
+    private _debouncedEvaluateBlock: PromiseFunction<null | Oni.Plugin.EvaluationResult>
+
     private _languageService: Oni.Plugin.LanguageService
 
     constructor(languageService: Oni.Plugin.LanguageService) {
@@ -38,6 +40,14 @@ export class DebouncedLanguageService implements Oni.Plugin.LanguageService {
         this._debouncedQuickInfo = debounce(async (context) => { // tslint:disable-line arrow-parens
             if (this._languageService.getQuickInfo) {
                 return this._languageService.getQuickInfo(context)
+            } else {
+                return null
+            }
+        })
+
+        this._debouncedEvaluateBlock = debounce(async (position: Oni.EventContext, id: string, fileName: string, code: string) => {
+            if (this._languageService.evaluateBlock) {
+                return this._languageService.evaluateBlock(position, id, fileName, code)
             } else {
                 return null
             }
@@ -76,11 +86,7 @@ export class DebouncedLanguageService implements Oni.Plugin.LanguageService {
         return this._debouncedGetSignatureHelp(position)
     }
 
-    public async evaluateBlock(position: Oni.EventContext, id: string, fileName: string, code: string): Promise<null | Oni.Plugin.EvaluationResult> {
-        if (this._languageService.evaluateBlock) {
-            return this._languageService.evaluateBlock(position, id, fileName, code)
-        } else {
-            return null
-        }
+    public evaluateBlock(position: Oni.EventContext, id: string, filename: string, code: string): Promise<null | Oni.Plugin.EvaluationResult> {
+        return this._debouncedEvaluateBlock(position, id, filename, code)
     }
 }

--- a/browser/src/Plugins/Api/DebouncedLanguageService.ts
+++ b/browser/src/Plugins/Api/DebouncedLanguageService.ts
@@ -10,8 +10,6 @@ export class DebouncedLanguageService implements Oni.Plugin.LanguageService {
     private _debouncedFormattingEdits: PromiseFunction<null | Oni.Plugin.FormattingEditsResponse>
     private _debouncedGetSignatureHelp: PromiseFunction<null | Oni.Plugin.SignatureHelpResult>
     private _debouncedQuickInfo: PromiseFunction<null | Oni.Plugin.QuickInfo>
-    private _debouncedEvaluateBlock: PromiseFunction<null | Oni.Plugin.EvaluationResult>
-
     private _languageService: Oni.Plugin.LanguageService
 
     constructor(languageService: Oni.Plugin.LanguageService) {
@@ -40,14 +38,6 @@ export class DebouncedLanguageService implements Oni.Plugin.LanguageService {
         this._debouncedQuickInfo = debounce(async (context) => { // tslint:disable-line arrow-parens
             if (this._languageService.getQuickInfo) {
                 return this._languageService.getQuickInfo(context)
-            } else {
-                return null
-            }
-        })
-
-        this._debouncedEvaluateBlock = debounce(async (position: Oni.EventContext, id: string, fileName: string, code: string) => {
-            if (this._languageService.evaluateBlock) {
-                return this._languageService.evaluateBlock(position, id, fileName, code)
             } else {
                 return null
             }
@@ -86,7 +76,11 @@ export class DebouncedLanguageService implements Oni.Plugin.LanguageService {
         return this._debouncedGetSignatureHelp(position)
     }
 
-    public evaluateBlock(position: Oni.EventContext, id: string, filename: string, code: string): Promise<null | Oni.Plugin.EvaluationResult> {
-        return this._debouncedEvaluateBlock(position, id, filename, code)
+    public async evaluateBlock(position: Oni.EventContext, id: string, fileName: string, code: string): Promise<null | Oni.Plugin.EvaluationResult> {
+        if (this._languageService.evaluateBlock) {
+            return this._languageService.evaluateBlock(position, id, fileName, code)
+        } else {
+            return null
+        }
     }
 }

--- a/vim/core/oni-plugin-typescript/src/LiveEvaluation.ts
+++ b/vim/core/oni-plugin-typescript/src/LiveEvaluation.ts
@@ -44,6 +44,7 @@ export const evaluateBlock = (id: string, fileName: string, code: string) => {
     const mod = new Module(fileName)
     const util = require("util")
     const sandbox = {
+        exports: {},
         module: mod,
         __filename: fileName,
         __dirname: path.dirname(fileName),


### PR DESCRIPTION
TypeScript code now emits a line that adds to the global exports object in the default settings - need to make sure that is available in the sandbox.