### PR TITLE
Fix #265 - Enable clicking on the `QuickOpen` and `Command` palettes

### DIFF
--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -7,8 +7,8 @@
  * http://redux.js.org/docs/basics/Actions.html
  */
 
-import { Rectangle } from "./Types"
 import * as Events from "./Events"
+import { Rectangle } from "./Types"
 
 export const setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
     type: "SET_CURSOR_POSITION",

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -73,7 +73,7 @@ export const nextMenu = () => ({
     type: "NEXT_MENU",
 })
 
-export const selectMenuItem = (dispatch: Function, getState: Function) => (openInSplit: boolean, index?: number) => {
+export const selectMenuItem = (openInSplit: boolean, index?: number) => (dispatch: Function, getState: Function) => {
 
     const state = getState()
 

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -8,6 +8,7 @@
  */
 
 import { Rectangle } from "./Types"
+import * as Events from "./Events"
 
 export const setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
     type: "SET_CURSOR_POSITION",
@@ -71,6 +72,22 @@ export const filterMenu = (filterString: string) => ({
 export const nextMenu = () => ({
     type: "NEXT_MENU",
 })
+
+export const selectMenuItem = (dispatch: Function, getState: Function) => (openInSplit: boolean, index?: number) => {
+
+    const state = getState()
+
+    if (!state || !state.popupMenu) {
+        return
+    }
+
+    const selectedIndex = index || state.popupMenu.selectedIndex
+    const selectedOption = state.popupMenu.filteredOptions[selectedIndex]
+
+    Events.events.emit("menu-item-selected:" + state.popupMenu.id, { selectedOption, openInSplit })
+
+    dispatch(hideMenu())
+}
 
 export const showQuickInfo = (title: string, description: string) => ({
     type: "SHOW_QUICK_INFO",

--- a/browser/src/UI/Events.ts
+++ b/browser/src/UI/Events.ts
@@ -1,0 +1,12 @@
+/**
+ * Events.ts
+ *
+ * Description of events that are emitted by the UI layer
+ */
+
+import { EventEmitter } from "events"
+
+export const events = new EventEmitter()
+
+export const CompletionItemSelectedEvent = "completion-item-selected"
+export const MenuItemSelectedEvent = "menu-item-selected"

--- a/browser/src/UI/Overlay/OverlayManager.ts
+++ b/browser/src/UI/Overlay/OverlayManager.ts
@@ -32,12 +32,18 @@ export class OverlayManager extends EventEmitter {
 
         this._screen = screen
 
+        // TODO: Refactor to component
         const div = document.createElement("div")
         div.style.position = "absolute"
         div.style.top = "0px"
         div.style.left = "0px"
         div.style.width = "100px"
         div.style.height = "100px"
+
+        // This is not a long-term solution, and to make things like mouse-events
+        // work on buffer scroll, or be useful for errors, we'll need to remove this
+        // and move this element to a proper spot in the DOM.
+        div.style.pointerEvents = "none"
         document.body.appendChild(div)
         this._containerElement = div
 

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -44,11 +44,15 @@
             flex-direction: row;
             align-items: center;
 
+            user-select: none;
+            -webkit-user-drag: none;
+            cursor: pointer;
+
             .fa:not(.fa-spin) {
                 padding-right: 8px;
             }
 
-            &.selected {
+            &.selected, &:hover {
                 background-color: @background-color-highlight;
             }
 

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -22,6 +22,7 @@ export interface IMenuProps {
     selectedIndex: number
     filterText: string
     onChangeFilterText: (text: string) => void
+    onSelect: (openInSplit: boolean, selectedIndex?: number) => void
     items: State.IMenuOptionWithHighlights[]
 }
 
@@ -42,6 +43,7 @@ export class Menu extends React.Component<IMenuProps, void> {
         const items = initialItems.map((menuItem, index) => <MenuItem {...menuItem as any} // FIXME: undefined
             filterText={this.props.filterText}
             isSelected={index === this.props.selectedIndex}
+            onClick={() => this.props.onSelect(false, index)}
             />)
 
         return <div className="menu-background">
@@ -93,8 +95,13 @@ const mapDispatchToProps = (dispatch: any) => {
         dispatch(ActionCreators.filterMenu(text))
     }
 
+    const selectItem = (openInSplit: boolean, selectedIndex: number) => {
+        dispatch(ActionCreators.selectMenuItem(openInSplit, selectedIndex))
+    }
+
     return {
         onChangeFilterText: dispatchFilterText,
+        onSelect: selectItem,
     }
 }
 
@@ -109,6 +116,7 @@ export interface IMenuItemProps {
     detail: string
     detailHighlights: number[]
     pinned: boolean
+    onClick: Function
 }
 
 export class MenuItem extends React.Component<IMenuItemProps, void> {
@@ -122,7 +130,7 @@ export class MenuItem extends React.Component<IMenuItemProps, void> {
 
         const icon = this.props.icon ? <Icon name={this.props.icon} /> : null
 
-        return <div className={className}>
+        return <div className={className} onClick={() => this.props.onClick()}>
             {icon}
             <HighlightTextByIndex className="label" text={this.props.label} highlightIndices={this.props.labelHighlights} highlightClassName={"highlight"} />
             <HighlightTextByIndex className="detail" text={this.props.detail} highlightIndices={this.props.detailHighlights} highlightClassName={"highlight"} />

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -100,7 +100,7 @@ export function previousPopupMenuItem(): void {
 }
 
 export function selectPopupMenuItem(openInSplit: boolean, menuItemIndex?: number): void {
-    ActionCreators.selectMenuItem(store.dispatch, store.getState)(openInSplit, menuItemIndex)
+    store.dispatch(ActionCreators.selectMenuItem(openInSplit, menuItemIndex))
 }
 
 export function showQuickInfo(title: string, description: string): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -3,7 +3,8 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 
 import { Provider } from "react-redux"
-import { createStore } from "redux"
+import { createStore, compose, applyMiddleware } from "redux"
+import thunk from "redux-thunk"
 
 import * as Config from "./../Config"
 
@@ -185,7 +186,13 @@ export function showNeovimInstallHelp(): void {
     ReactDOM.render(<InstallHelp />, element)
 }
 
-const store = createStore(reducer, defaultState, window["__REDUX_DEVTOOLS_EXTENSION__"] && window["__REDUX_DEVTOOLS_EXTENSION__"]()) // tslint:disable-line no-string-literal
+
+const composeEnhancers = window["__REDUX_DEVTOOLS_EXTENSION__COMPOSE__"] || compose // tslint:disable-line no-string-literal
+const enhancer = composeEnhancers(
+    applyMiddleware(thunk),
+)
+
+const store = createStore(reducer, defaultState, enhancer)
 
 export function init(): void {
     render(defaultState)

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -1,4 +1,3 @@
-import { EventEmitter } from "events"
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
@@ -20,11 +19,11 @@ import { InstallHelp } from "./components/InstallHelp"
 
 import { IScreen } from "./../Screen"
 
-export const events = new EventEmitter()
+import * as Events from "./Events"
+
+export const events = Events.events
 
 let defaultState = State.createDefaultState()
-
-const CompletionItemSelectedEvent = "completion-item-selected"
 
 export function setBackgroundColor(backgroundColor: string): void {
     const backgroundImageElement: HTMLElement = document.getElementsByClassName("background-image")[0] as HTMLElement
@@ -100,19 +99,8 @@ export function previousPopupMenuItem(): void {
     store.dispatch(ActionCreators.previousMenu())
 }
 
-export function selectPopupMenuItem(openInSplit: boolean): void {
-    const state = store.getState() as State.IState
-
-    if (!state || !state.popupMenu) {
-        return
-    }
-
-    const selectedIndex = state.popupMenu.selectedIndex // FIXME: null
-    const selectedOption = state.popupMenu.filteredOptions[selectedIndex] // FIXME: null
-
-    events.emit("menu-item-selected:" + state.popupMenu.id, { selectedOption, openInSplit })
-
-    hidePopupMenu()
+export function selectPopupMenuItem(openInSplit: boolean, menuItemIndex?: number): void {
+    ActionCreators.selectMenuItem(store.dispatch, store.getState)(openInSplit, menuItemIndex)
 }
 
 export function showQuickInfo(title: string, description: string): void {
@@ -177,7 +165,7 @@ function emitCompletionItemSelectedEvent(): void {
     const autoCompletion = store.getState().autoCompletion
     if (autoCompletion != null) {
         const entry = autoCompletion.entries[autoCompletion.selectedIndex]
-        events.emit(CompletionItemSelectedEvent, entry)
+        events.emit(Events.CompletionItemSelectedEvent, entry)
     }
 }
 

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 
 import { Provider } from "react-redux"
-import { createStore, compose, applyMiddleware } from "redux"
+import { compose, createStore, applyMiddleware } from "redux"
 import thunk from "redux-thunk"
 
 import * as Config from "./../Config"
@@ -173,7 +173,6 @@ export function showNeovimInstallHelp(): void {
     const element = document.getElementById("overlay-ui")
     ReactDOM.render(<InstallHelp />, element)
 }
-
 
 const composeEnhancers = window["__REDUX_DEVTOOLS_EXTENSION__COMPOSE__"] || compose // tslint:disable-line no-string-literal
 const enhancer = composeEnhancers(

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 
 import { Provider } from "react-redux"
-import { compose, createStore, applyMiddleware } from "redux"
+import { applyMiddleware, compose, createStore } from "redux"
 import thunk from "redux-thunk"
 
 import * as Config from "./../Config"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-measure": "1.4.2",
     "react-redux": "4.4.5",
     "redux": "3.5.2",
+    "redux-thunk": "2.2.0",
     "typescript": "2.2.1",
     "wcwidth": "1.0.1"
   },
@@ -75,6 +76,7 @@
     "@types/react-dom": "0.14.18",
     "@types/react-measure": "0.4.5",
     "@types/react-redux": "4.4.32",
+    "@types/redux-thunk": "^2.1.0",
     "@types/sinon": "1.16.32",
     "autoprefixer": "6.4.0",
     "concurrently": "3.1.0",


### PR DESCRIPTION
- Refactor the `selectMenuItem` action to an `ActionCreator`, so that it can be hooked up to the UI via mapStateToDispatch
- Add `redux-thunk`, because the action creator is conditional based on some info in the state
- Wire up the click events through `Menu` and `MenuItem`
- Add CSS styles for hover and mouse over
- Temporarily disable pointer events on the `overlays` (errors, buffer scrollbar), since they don't handle mouse events today, they are rendered on top of all other UI. Long-term, we'll need to move this to a more reasonable location in the DOM (refactor to a component)