### PR TITLE
add editor.exclude config for Fuzzy Finder

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -50,7 +50,7 @@ const DefaultConfig: any = {
     "editor.completions.enabled": true,
     "editor.errors.slideOnFocus": true,
     "editor.formatting.formatOnSwitchToNormalMode": false, // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
-    "editor.excludeDirs": ["**/node_modules/**"],
+    "editor.exclude": ["**/node_modules/**"],
 
     // Command to list files for 'quick open'
     // For example, to use 'ag': ag --nocolor -l .

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -50,6 +50,7 @@ const DefaultConfig: any = {
     "editor.completions.enabled": true,
     "editor.errors.slideOnFocus": true,
     "editor.formatting.formatOnSwitchToNormalMode": false, // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
+    "editor.excludeDirs": ["**/node_modules/**"],
 
     // Command to list files for 'quick open'
     // For example, to use 'ag': ag --nocolor -l .

--- a/browser/src/Services/Git.ts
+++ b/browser/src/Services/Git.ts
@@ -26,7 +26,8 @@ export function getTrackedFiles(): Q.Promise<string[]> {
     return Q.resolve(trackedFiles)
 }
 
-export function getUntrackedFiles(): Q.Promise<string[]> {
-    const untrackedFiles = execSync("git ls-files --others --exclude-standard").toString("utf8").split("\n")
+export function getUntrackedFiles(exclude: string[]): Q.Promise<string[]> {
+    let cmd = "git ls-files --others --exclude-standard" + exclude.map((dir) => " -x " + dir).join("")
+    const untrackedFiles = execSync(cmd).toString("utf8").split("\n")
     return Q.resolve(untrackedFiles)
 }

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -35,7 +35,7 @@ export class QuickOpen {
         })
     }
 
-    public show(): void {
+    public show(exclude: string[]): void {
         const overrriddenCommand = Config.getValue<string>("editor.quickOpen.execCommand")
 
         UI.showPopupMenu("quickOpen", [{
@@ -60,7 +60,7 @@ export class QuickOpen {
         const openPromise = Git.isGitRepository()
             .then((isGit) => {
                 if (isGit) {
-                    return Q.all([Git.getTrackedFiles(), Git.getUntrackedFiles()])
+                    return Q.all([Git.getTrackedFiles(), Git.getUntrackedFiles(exclude)])
                         .then((values: [string[], string[]]) => {
                             const allFiles = _.flatten(values)
                             this._showMenuFromFiles(allFiles)
@@ -69,7 +69,7 @@ export class QuickOpen {
                     // TODO: This async call is being dropped, if we happen to use the promise
                     return glob("**/*", {
                         nodir: true,
-                        ignore: ["**/node_modules/**"], // all hidden dirs (start with '.') are skipped by default
+                        ignore: exclude,
                     }, (_err: any, files: string[]) => {
                         this._showMenuFromFiles(files)
                     })

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -299,7 +299,7 @@ const start = (args: string[]) => {
         if (key === "<f12>") {
             commandManager.executeCommand("oni.editor.gotoDefinition", null)
         } else if (key === "<C-p>" && screen.mode === "normal") {
-            quickOpen.show()
+            quickOpen.show(Config.getValue<string[]>("editor.excludeDirs"))
         } else if (key === "<C-P>" && screen.mode === "normal") {
             tasks.show()
         } else if (key === "<C-pageup>") {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -299,7 +299,7 @@ const start = (args: string[]) => {
         if (key === "<f12>") {
             commandManager.executeCommand("oni.editor.gotoDefinition", null)
         } else if (key === "<C-p>" && screen.mode === "normal") {
-            quickOpen.show(Config.getValue<string[]>("editor.excludeDirs"))
+            quickOpen.show(Config.getValue<string[]>("editor.exclude"))
         } else if (key === "<C-P>" && screen.mode === "normal") {
             tasks.show()
         } else if (key === "<C-pageup>") {


### PR DESCRIPTION
Add support for `editor.exclude` in config.js to affect Fuzzy Finder.  Default is still `**/node_modules/**`.  This works great outside of git repositories and I'm *pretty* sure it works within git repositories.  The exclude list for `git-ls` only applies to untracked files and I'm still including `--exclude-standard` which includes the whole `.gitignore` file so I don't have too many files left to try excluding.