### PR TITLE
Fix wrapping around first/last item in menu

### DIFF
--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -91,6 +91,9 @@ export const reducer = (s: State.IState, a: Actions.Action) => {
 
 export const popupMenuReducer = (s: State.IMenu | null, a: Actions.Action) => {
 
+    // TODO: sync max display items (10) with value in Menu.render() (Menu.tsx)
+    let size = s ? Math.min(10, s.filteredOptions.length) : 0
+
     switch (a.type) {
         case "SHOW_MENU":
             const sortedOptions = _.sortBy(a.payload.options, (f) => f.pinned ? 0 : 1).map((o) => ({
@@ -117,7 +120,7 @@ export const popupMenuReducer = (s: State.IMenu | null, a: Actions.Action) => {
             }
 
             return Object.assign({}, s, {
-                selectedIndex: (s.selectedIndex + 1) % s.filteredOptions.length,
+                selectedIndex: (s.selectedIndex + 1) % size,
             })
         case "PREVIOUS_MENU":
             if (!s) {
@@ -125,8 +128,7 @@ export const popupMenuReducer = (s: State.IMenu | null, a: Actions.Action) => {
             }
 
             return Object.assign({}, s, {
-                selectedIndex: (s.selectedIndex - 1) % s.filteredOptions.length,
-
+                selectedIndex: s.selectedIndex > 0 ? s.selectedIndex - 1 : size - 1,
             })
         case "FILTER_MENU":
             if (!s) {

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -36,6 +36,7 @@ export class Menu extends React.Component<IMenuProps, void> {
             return null
         }
 
+        // TODO: sync max display items (10) with value in Reducer.popupMenuReducer() (Reducer.ts)
         const initialItems = _.take(this.props.items, 10)
 
         // const pinnedItems = initialItems.filter(f => f.pinned)


### PR DESCRIPTION
This Pull Request fixes two specific issues in the Fuzzy Finder and Command Palette:

1. When on the first item, hitting `Ctrl+P` to go to the previous item would run `selectedIndex -1 % length` but for whatever reason, in javascript, `-1 % x` equals `-1` and not `x-1`.  So rather than wrapping around to the last item in the list it was setting `selectedIndex` to `-1` and the highlight would just disappear.  Every subsequent `Ctrl+P` would just keep decrementing to `-2`, `-3`, etc.
2. When on the last item, hitting `Ctrl+N` to go to the next item would run `selectedIndex +1 % length`.  Unfortunately, the `length` property was based on the full list of options, not the number of options currently displayed.  So the highlight would disappear until you hit `Ctrl+N` enough times to wrap around the *actual* list.

To fix these issues, I did the following:
1. If `selectedIndex = 0`, just set the `selectedIndex` to `length - 1`.
2. Set `length` to `Math.min(10, length)` so if there are more than 10 entries in the list we'll just loop over the 10 visible entries.

There's one thing I don't like about this fix.  `Menu.tsx` is hardcoded to just display the first 10 items but in `Reducer.ts`, where we're handling the next/previous operation, we don't know how many items `Menu.tsx` truncated the list to.  I was hoping to set a variable that was accessible by both classes so they could stay in sync but `Menu.tsx` has a `IMenuProps` and `Reducer.ts` has a `IMenu`.  I couldn't find a way to access a `maxDisplayItems` in both classes.  So I just hardcoded `10` in `Reducer.ts` with a big ugly `TODO`.  If you have a way to access a variable in both of those classes please let me know so I can clean it up.