### PR TITLE
Fix wrapping around first/last item in autocomplete

### DIFF
--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -247,7 +247,8 @@ export const autoCompletionReducer = (s: State.IAutoCompletionInfo | null, a: Ac
         return s
     }
 
-    const currentEntryCount = s.entries.length
+    // TODO: sync max display items (10) with value in AutoCompletion.render() (AutoCompletion.tsx)
+    const currentEntryCount = Math.min(10, s.entries.length)
 
     switch (a.type) {
         case "NEXT_AUTO_COMPLETION":
@@ -256,7 +257,7 @@ export const autoCompletionReducer = (s: State.IAutoCompletionInfo | null, a: Ac
             })
         case "PREVIOUS_AUTO_COMPLETION":
             return Object.assign({}, s, {
-                selectedIndex: (s.selectedIndex - 1) % currentEntryCount,
+                selectedIndex: s.selectedIndex > 0 ? s.selectedIndex - 1 : currentEntryCount - 1,
             })
         default:
             return Object.assign({}, s, {

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -45,6 +45,7 @@ export class AutoCompletion extends React.Component<IAutoCompletionProps, void> 
             return null
         }
 
+        // TODO: sync max display items (10) with value in Reducer.autoCompletionReducer() (Reducer.ts)
         const firstTenEntries = _.take(this.props.entries, 10)
 
         const entries = firstTenEntries.map((s, i) => {


### PR DESCRIPTION
Same basic concept as #280.  I didn't realize we had the same logic in autocomplete or I would've fixed them both at the same time.