### PR TITLE
Reduce duplication in .less files

### DIFF
--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -1,9 +1,10 @@
+@import (reference) "./common.less";
 
 .autocompletion {
-    background-color: rgb(40, 40, 40);
+    background-color: @background-color;
     border: 1px solid gray;
-    box-shadow: 4px 4px rgba(0, 0, 0, 0.2);
-    color: rgb(200, 200, 200);
+    box-shadow: 4px 4px @shadow-color;
+    color: @text-color;
     max-width: 800px;
     max-height: 300px;
     overflow-x: hidden;
@@ -53,7 +54,7 @@
             .highlight {
                 font-weight: bold;
                 font-style: italic;
-                color: rgb(50, 200, 255);
+                color: @text-color-highlight;
             }
         }
 
@@ -67,14 +68,14 @@
             white-space: nowrap;
             margin-left: 16px;
 
-            color: rgba(100, 100, 100, 0.6);
+            color: @text-color-detail;
 
             font-size: 11px;
         }
 
         .documentation {
             font-size: 10px;
-            color: rgb(50, 200, 255);
+            color: @text-color-highlight;
         }
     }
 }

--- a/browser/src/UI/components/Error.less
+++ b/browser/src/UI/components/Error.less
@@ -36,7 +36,7 @@
 
         .text {
             font-size: 10px;
-            color: rgb(200, 200, 200);
+            color: @text-color;
             text-overflow: ellipsis;
             overflow: hidden;
             text-align: center;

--- a/browser/src/UI/components/LiveEvalMarker.less
+++ b/browser/src/UI/components/LiveEvalMarker.less
@@ -6,7 +6,7 @@
     position: absolute;
     right: 0px;
     background-color: rgba(0, 0, 0, 0.4);
-    color: rgb(200, 200, 200);
+    color: @text-color;
     width: @liveEvalGutterSize;
     border-left: 1px solid green;
 

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -52,7 +52,10 @@
                 padding-right: 8px;
             }
 
-            &.selected, &:hover {
+            &:hover {
+                background-color: fade(@background-color-highlight, 10%);
+            }
+            &.selected {
                 background-color: @background-color-highlight;
             }
 

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -20,7 +20,7 @@
     border: 1px solid rgb(60, 60, 60);
     padding: 8px;
 
-    box-shadow: 4px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 4px 4px @shadow-color;
     width: 600px;
     max-height: 400px;
 

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -9,7 +9,7 @@
         background-color: @background-color;
         border: 1px solid gray;
         padding: 4px;
-        box-shadow: 4px 4px rgba(0, 0, 0, 0.2);
+        box-shadow: 4px 4px @shadow-color;
         color: @text-color;
         text-overflow: ellipsis;
         overflow: hidden;

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -6,7 +6,9 @@
 // Colors
 @text-color: rgb(200, 200, 200);
 @text-color-highlight: rgb(50, 200, 255);
-@text-color-detail: rgba(100, 100, 100, 0.6);
+@text-color-detail: rgb(100, 100, 100);
+
+@shadow-color: rgba(0, 0, 0, 0.2);
 
 @background-color: rgb(40, 40, 40);
 @background-color-highlight: rgba(100, 200, 255, 0.2);


### PR DESCRIPTION
I noticed there were hardcoded colors in some `.less` files that were already defined in `common.less` so this is just some cleanup to use the variable from `common.less` instead.  The only visual change I made was to the `detail` color in the menu and autocompletion.  I think the detail text was too dim so I got rid of the alpha value but kept the color the same.