### PR TITLE
Fix #236, refresh Config object anytime config.js changes, notify any listeners

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -96,7 +96,6 @@ function applyConfig(): void {
     Config = { ...DefaultConfig, ...DefaultPlatformConfig, ...userRuntimeConfig }
 }
 
-
 applyConfig()
 // use watch() on the directory rather than on config.js because it watches
 // file references and changing a file in Vim typically saves a tmp file

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -245,6 +245,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             .then((buf: any) => new Buffer(buf))
     }
 
+    public getCurrentWorkingDirectory(): Q.Promise<string> {
+        return this.eval("getcwd()")
+                .then((currentWorkingDirectory: string) => path.normalize(currentWorkingDirectory))
+    }
+
     public getCurrentWindow(): Q.Promise<IWindow> {
         return this._sessionWrapper.invoke<any>("nvim_get_current_win", [])
             .then((win: any) => new Window(win))

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -35,8 +35,9 @@ export class QuickOpen {
         })
     }
 
-    public show(exclude: string[]): void {
+    public show(): void {
         const overrriddenCommand = Config.getValue<string>("editor.quickOpen.execCommand")
+        const exclude = Config.getValue<string[]>("editor.exclude")
 
         UI.showPopupMenu("quickOpen", [{
             icon: "refresh fa-spin fa-fw",

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -166,6 +166,11 @@ const start = (args: string[]) => {
             UI.hideSignatureHelp()
             UI.hideQuickInfo()
         }
+
+        if (eventName === "DirChanged") {
+            instance.getCurrentWorkingDirectory()
+                .then((newDirectory) => process.chdir(newDirectory))
+        }
     })
 
     instance.on("show-popup-menu", (completions: any[]) => {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -41,22 +41,11 @@ const start = (args: string[]) => {
 
     const parsedArgs = minimist(args)
 
-    const cursorLine = Config.getValue<boolean>("editor.cursorLine")
-    const cursorColumn = Config.getValue<boolean>("editor.cursorColumn")
-    UI.setCursorLineOpacity(Config.getValue<number>("editor.cursorLineOpacity"))
-    UI.setCursorColumnOpacity(Config.getValue<number>("editor.cursorColumnOpacity"))
-
-    if (cursorLine) {
-        UI.showCursorLine()
-    }
-
-    if (cursorColumn) {
-        UI.showCursorColumn()
-    }
+    let cursorLine: boolean
+    let cursorColumn: boolean
 
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
-    remote.getCurrentWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
     require("./overlay.less")
 
     let deltaRegion = new IncrementalDeltaRegionTracker()
@@ -261,7 +250,28 @@ const start = (args: string[]) => {
         pendingTimeout = null
     }
 
-    instance.setFont(Config.getValue<string>("editor.fontFamily"), Config.getValue<string>("editor.fontSize"))
+    const configChange = () => {
+        cursorLine = Config.getValue<boolean>("editor.cursorLine")
+        cursorColumn = Config.getValue<boolean>("editor.cursorColumn")
+        UI.setCursorLineOpacity(Config.getValue<number>("editor.cursorLineOpacity"))
+        UI.setCursorColumnOpacity(Config.getValue<number>("editor.cursorColumnOpacity"))
+
+        if (cursorLine) {
+            UI.showCursorLine()
+        }
+
+        if (cursorColumn) {
+            UI.showCursorColumn()
+        }
+
+        remote.getCurrentWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
+        instance.setFont(Config.getValue<string>("editor.fontFamily"), Config.getValue<string>("editor.fontSize"))
+        renderFunction()
+        updateFunction()
+    }
+    configChange() // initialize values
+    Config.registerListener(configChange)
+
     instance.start(parsedArgs._)
 
     const mouse = new Mouse(editorElement, screen)
@@ -327,7 +337,7 @@ const start = (args: string[]) => {
         if (key === "<f12>") {
             commandManager.executeCommand("oni.editor.gotoDefinition", null)
         } else if (key === "<C-p>" && screen.mode === "normal") {
-            quickOpen.show(Config.getValue<string[]>("editor.exclude"))
+            quickOpen.show()
         } else if (key === "<C-P>" && screen.mode === "normal") {
             tasks.show()
         } else if (key === "<C-pageup>") {

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -62,6 +62,7 @@ augroup OniEventListeners
     autocmd! CursorMovedI * :call OniNotifyEvent("CursorMovedI")
     autocmd! InsertLeave * :call OniNotifyEvent("InsertLeave")
     autocmd! InsertEnter * :call OniNotifyEvent("InsertEnter")
+    autocmd! DirChanged * :call OniNotifyEvent("DirChanged")
 augroup END
 
 function OniGetContext()


### PR DESCRIPTION
The main difficulty here was that `Config.ts` is just a collection of methods, not a class or even a module.  If it was a class I could've had it `extend EventEmitter` but that would require changing how the class is accessed.  Also, we would've had to create an instance of the class, and singletons are discouraged in typescript.  Modules can't extend classes either so I decided to just leave it as a collection of methods and implement a simple [Observer pattern](https://en.wikipedia.org/wiki/Observer_pattern).

At first I thought I'd have to change every class that uses `Config` to register a listener for changes.  However, most classes that use `Config` just fetch the value as needed, rather than fetching the value and referring to it later.  So most classes will pull the latest value when they want and they don't care if (or when) it changed.  The only exception I found was in `index.tsx`, where most of the initialization takes place.  So that's the only class that currently registers listeners.

The only place I see where properties won't automatically change is in `NeovimInstance.ts`, with `oni.loadInitVim` and `oni.useDefaultConfig`.  This is because we only launch neovim once.  We *could* kill and re-launch neovim if these properties change but that seems quite drastic so I'll let @extr0py do it if he wants.