### PR TITLE
Fix #236, refresh Config object anytime config.js changes, notify any listeners

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -137,7 +137,12 @@ class Config extends EventEmitter {
     private applyConfig(): void {
         let userRuntimeConfig = {}
         if (fs.existsSync(this.userJsConfig)) {
-            userRuntimeConfig = global["require"](this.userJsConfig) // tslint:disable-line no-string-literal
+            try {
+                userRuntimeConfig = global["require"](this.userJsConfig) // tslint:disable-line no-string-literal
+            } catch (e) {
+                // TODO: display this error to the user somehow
+                console.log("Failed to parse " + this.userJsConfig + ": " + (<Error>e).message) // tslint:disable-line no-console
+            }
         }
         this.Config = { ...this.DefaultConfig, ...this.DefaultPlatformConfig, ...userRuntimeConfig }
     }

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -94,9 +94,6 @@ class Config extends EventEmitter {
 
         Performance.mark("Config.load.start")
 
-        let userConfig = {}
-        let userRuntimeConfig = {}
-
         this.applyConfig()
         // use watch() on the directory rather than on config.js because it watches
         // file references and changing a file in Vim typically saves a tmp file
@@ -114,7 +111,6 @@ class Config extends EventEmitter {
             }
         })
 
-        this.Config = { ...this.DefaultConfig, ...this.DefaultPlatformConfig, ...userConfig, ...userRuntimeConfig }
         Performance.mark("Config.load.end")
     }
 
@@ -134,7 +130,7 @@ class Config extends EventEmitter {
         this.configChanged.on("config-change", callback)
     }
 
-    public removeEventListener(callback: Function): void {
+    public removeListener(callback: Function): void {
         this.configChanged.removeListener("config-change", callback)
     }
 

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -1,109 +1,156 @@
+import { EventEmitter } from "events"
 import * as fs from "fs"
 import * as path from "path"
 
 import * as Performance from "./Performance"
 import * as Platform from "./Platform"
 
-export const FallbackFonts = "Consolas,Monaco,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace"
+class Config extends EventEmitter {
 
-const DefaultConfig: any = {
-    // Debug settings
-    "debug.incrementalRenderRegions": false,
+    public userJsConfig = path.join(this.getUserFolder(), "config.js")
 
-    // Prototype settings
-    "prototype.editor.backgroundOpacity": 0.7,
-    "prototype.editor.backgroundImageUrl": "images/background.png",
-    "prototype.editor.backgroundImageSize": "initial",
+    private DefaultConfig: any = {
+        // Debug settings
+        "debug.incrementalRenderRegions": false,
 
-    "prototype.editor.maxCellsToRender": 12000,
+        // Prototype settings
+        "prototype.editor.backgroundOpacity": 0.7,
+        "prototype.editor.backgroundImageUrl": "images/background.png",
+        "prototype.editor.backgroundImageSize": "initial",
 
-    // Bell sound effect to use
-    // See `:help bell` for instances where the bell sound would be used
-    "oni.audio.bellUrl": path.join(__dirname, "audio", "beep.wav"),
+        "prototype.editor.maxCellsToRender": 12000,
 
-    // Production settings
+        // Bell sound effect to use
+        // See `:help bell` for instances where the bell sound would be used
+        "oni.audio.bellUrl": path.join(__dirname, "audio", "beep.wav"),
 
-    // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
-    // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
-    //
-    // Set this to 'false' to avoid loading the default config, and load settings from init.vim instead.
-    "oni.useDefaultConfig": true,
+        // Production settings
 
-    // By default, user's init.vim is not loaded, to avoid conflicts.
-    // Set this to `true` to enable loading of init.vim.
-    "oni.loadInitVim": false,
+        // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
+        // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
+        //
+        // Set this to 'false' to avoid loading the default config, and load settings from init.vim instead.
+        "oni.useDefaultConfig": true,
 
-    // Sets the `popupmenu_external` option in Neovim
-    // This will override the default UI to show a consistent popupmenu,
-    // whether using Oni's completion mechanisms or VIMs
-    //
-    // Use caution when changing the `menuopt` parameters if using
-    // a custom init.vim, as that may cause problematic behavior
-    "oni.useExternalPopupMenu": true,
+        // By default, user's init.vim is not loaded, to avoid conflicts.
+        // Set this to `true` to enable loading of init.vim.
+        "oni.loadInitVim": false,
 
-    "editor.fontSize": "14px",
-    "editor.quickInfo.enabled": true,
+        // Sets the `popupmenu_external` option in Neovim
+        // This will override the default UI to show a consistent popupmenu,
+        // whether using Oni's completion mechanisms or VIMs
+        //
+        // Use caution when changing the `menuopt` parameters if using
+        // a custom init.vim, as that may cause problematic behavior
+        "oni.useExternalPopupMenu": true,
 
-    // Delay (in ms) for showing QuickInfo, when the cursor is on a term
-    "editor.quickInfo.delay": 500,
+        "editor.fontSize": "14px",
+        "editor.quickInfo.enabled": true,
 
-    "editor.completions.enabled": true,
-    "editor.errors.slideOnFocus": true,
-    "editor.formatting.formatOnSwitchToNormalMode": false, // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
-    "editor.exclude": ["**/node_modules/**"],
+        // Delay (in ms) for showing QuickInfo, when the cursor is on a term
+        "editor.quickInfo.delay": 500,
 
-    // Command to list files for 'quick open'
-    // For example, to use 'ag': ag --nocolor -l .
-    //
-    // The command must emit a list of filenames
-    //
-    // IE, Windows:
-    // "editor.quickOpen.execCommand": "dir /s /b"
-    "editor.fullScreenOnStart" : false,
+        "editor.completions.enabled": true,
+        "editor.errors.slideOnFocus": true,
+        "editor.formatting.formatOnSwitchToNormalMode": false, // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
+        "editor.exclude": ["**/node_modules/**"],
 
-    "editor.cursorLine": true,
-    "editor.cursorLineOpacity" : 0.1,
+        // Command to list files for 'quick open'
+        // For example, to use 'ag': ag --nocolor -l .
+        //
+        // The command must emit a list of filenames
+        //
+        // IE, Windows:
+        // "editor.quickOpen.execCommand": "dir /s /b"
+        "editor.fullScreenOnStart" : false,
 
-    "editor.cursorColumn": false,
-    "editor.cursorColumnOpacity": 0.1,
+        "editor.cursorLine": true,
+        "editor.cursorLineOpacity" : 0.1,
+
+        "editor.cursorColumn": false,
+        "editor.cursorColumnOpacity": 0.1,
+    }
+
+    private MacConfig: any = {
+        "editor.fontFamily": "Monaco",
+    }
+
+    private WindowsConfig: any = {
+        "editor.fontFamily": "Consolas",
+    }
+
+    private LinuxConfig: any = {
+        "editor.fontFamily": "DejaVu Sans Mono",
+    }
+
+    private DefaultPlatformConfig = Platform.isWindows() ? this.WindowsConfig : Platform.isLinux() ? this.LinuxConfig : this.MacConfig
+
+    private configChanged: EventEmitter = new EventEmitter()
+
+    private Config: any = {}
+
+    constructor() {
+        super()
+
+        Performance.mark("Config.load.start")
+
+        let userConfig = {}
+        let userRuntimeConfig = {}
+
+        this.applyConfig()
+        // use watch() on the directory rather than on config.js because it watches
+        // file references and changing a file in Vim typically saves a tmp file
+        // then moves it over to the original filename, causing watch() to lose its
+        // reference. Instead, watch() can watch the folder for the file changes
+        // and continue to fire when file references are swapped out.
+        // Unfortunately, this also means the 'change' event fires twice.
+        // I could use watchFile() but that polls every 5 seconds.  Not ideal.
+        fs.watch(this.getUserFolder(), (event, filename) => {
+            if (event === "change" && filename === "config.js") {
+                // invalidate the Config currently stored in cache
+                delete global["require"].cache[global["require"].resolve(this.userJsConfig)] // tslint:disable-line no-string-literal
+                this.applyConfig()
+                this.notifyListeners()
+            }
+        })
+
+        this.Config = { ...this.DefaultConfig, ...this.DefaultPlatformConfig, ...userConfig, ...userRuntimeConfig }
+        Performance.mark("Config.load.end")
+    }
+
+    public hasValue(configValue: string): boolean {
+        return !!this.getValue<any>(configValue)
+    }
+
+    public getValue<T>(configValue: string): T {
+        return this.Config[configValue]
+    }
+
+    public getUserFolder(): string {
+        return path.join(Platform.getUserHome(), ".oni")
+    }
+
+    public registerListener(callback: Function): void {
+        this.configChanged.on("config-change", callback)
+    }
+
+    public removeEventListener(callback: Function): void {
+        this.configChanged.removeListener("config-change", callback)
+    }
+
+    private applyConfig(): void {
+        let userRuntimeConfig = {}
+        if (fs.existsSync(this.userJsConfig)) {
+            userRuntimeConfig = global["require"](this.userJsConfig) // tslint:disable-line no-string-literal
+        }
+        this.Config = { ...this.DefaultConfig, ...this.DefaultPlatformConfig, ...userRuntimeConfig }
+    }
+
+    private notifyListeners(): void {
+        this.configChanged.emit("config-change")
+    }
+
 }
 
-const MacConfig: any = {
-    "editor.fontFamily": "Monaco",
-}
-
-const WindowsConfig: any = {
-    "editor.fontFamily": "Consolas",
-}
-
-const LinuxConfig: any = {
-    "editor.fontFamily": "DejaVu Sans Mono",
-}
-
-const DefaultPlatformConfig = Platform.isWindows() ? WindowsConfig : Platform.isLinux() ? LinuxConfig : MacConfig
-
-Performance.mark("Config.load.start")
-
-export const userJsConfig = path.join(getUserFolder(), "config.js")
-
-let userConfig = {}
-let userRuntimeConfig = {}
-
-if (fs.existsSync(userJsConfig)) {
-    userRuntimeConfig = global["require"](userJsConfig) // tslint:disable-line no-string-literal
-}
-
-const Config = { ...DefaultConfig, ...DefaultPlatformConfig, ...userConfig, ...userRuntimeConfig }
-Performance.mark("Config.load.end")
-
-export function hasValue(configValue: string): boolean {
-    return !!getValue<any>(configValue)
-}
-
-export function getValue<T>(configValue: string): T {
-    return Config[configValue]
-}
-
-export function getUserFolder(): string {
-    return path.join(Platform.getUserHome(), ".oni")
-}
+const _config = new Config()
+export const instance = () => _config

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -130,7 +130,7 @@ class Config extends EventEmitter {
         this.configChanged.on("config-change", callback)
     }
 
-    public removeListener(callback: Function): void {
+    public unregisterListener(callback: Function): void {
         this.configChanged.removeListener("config-change", callback)
     }
 

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -58,8 +58,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _neovim: any
     private _initPromise: any
 
-    private _fontFamily: string = Config.getValue<string>("editor.fontFamily")
-    private _fontSize: string = Config.getValue<string>("editor.fontSize")
+    private _config = Config.instance()
+
+    private _fontFamily: string = this._config.getValue<string>("editor.fontFamily")
+    private _fontSize: string = this._config.getValue<string>("editor.fontSize")
     private _fontWidthInPixels: number
     private _fontHeightInPixels: number
 
@@ -284,8 +286,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private _resizeInternal(rows: number, columns: number): void {
 
-        if (Config.hasValue("debug.fixedSize")) {
-            const fixedSize = Config.getValue<any>("debug.fixedSize")
+        if (this._config.hasValue("debug.fixedSize")) {
+            const fixedSize = this._config.getValue<any>("debug.fixedSize")
             rows = fixedSize.rows
             columns = fixedSize.columns
             console.warn("Overriding screen size based on debug.fixedSize")
@@ -372,7 +374,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 const completions = a[0][0]
                 this.emit("show-popup-menu", completions)
             } else if (command === "bell") {
-                const bellUrl = Config.getValue<string>("oni.audio.bellUrl")
+                const bellUrl = this._config.getValue<string>("oni.audio.bellUrl")
                 if (bellUrl) {
                     const audio = new Audio(bellUrl)
                     audio.play()
@@ -397,8 +399,8 @@ function startNeovim(runtimePaths: string[], args: any): Q.IPromise<any> {
 
     const joinedRuntimePaths = runtimePaths.join(",")
 
-    const shouldLoadInitVim = Config.getValue<boolean>("oni.loadInitVim")
-    const useDefaultConfig = Config.getValue<boolean>("oni.useDefaultConfig")
+    const shouldLoadInitVim = Config.instance().getValue<boolean>("oni.loadInitVim")
+    const useDefaultConfig = Config.instance().getValue<boolean>("oni.useDefaultConfig")
 
     const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -24,6 +24,7 @@ export interface IEventContext {
 }
 
 export class PluginManager extends EventEmitter {
+    private _config = Config.instance()
     private _rootPluginPaths: string[] = []
     private _extensionPath: string
     private _plugins: Plugin[] = []
@@ -39,7 +40,7 @@ export class PluginManager extends EventEmitter {
 
         this._rootPluginPaths.push(corePluginsRoot)
 
-        if (Config.getValue<boolean>("oni.useDefaultConfig")) {
+        if (this._config.getValue<boolean>("oni.useDefaultConfig")) {
             this._rootPluginPaths.push(defaultPluginsRoot)
             this._rootPluginPaths.push(path.join(defaultPluginsRoot, "bundle"))
         }
@@ -47,7 +48,7 @@ export class PluginManager extends EventEmitter {
         this._extensionPath = this._ensureOniPluginsPath()
         this._rootPluginPaths.push(this._extensionPath)
 
-        this._rootPluginPaths.push(path.join(Config.getUserFolder(), "plugins"))
+        this._rootPluginPaths.push(path.join(this._config.getUserFolder(), "plugins"))
 
         this._channel.host.onResponse((arg: any) => this._handlePluginResponse(arg))
     }
@@ -162,7 +163,7 @@ export class PluginManager extends EventEmitter {
                         return
                     }
                     UI.showQuickInfo(pluginResponse.payload.info, pluginResponse.payload.documentation)
-                }, Config.getValue<number>("editor.quickInfo.delay"))
+                }, this._config.getValue<number>("editor.quickInfo.delay"))
             } else {
                 setTimeout(() => UI.hideQuickInfo())
             }
@@ -219,10 +220,10 @@ export class PluginManager extends EventEmitter {
             },
         }, Capabilities.createPluginFilter(this._lastEventContext.filetype, { subscriptions: ["vim-events"] }, false))
 
-        if (eventName === "CursorMoved" && Config.getValue<boolean>("editor.quickInfo.enabled")) {
+        if (eventName === "CursorMoved" && this._config.getValue<boolean>("editor.quickInfo.enabled")) {
             this._sendLanguageServiceRequest("quick-info", eventContext)
 
-        } else if (eventName === "CursorMovedI" && Config.getValue<boolean>("editor.completions.enabled")) {
+        } else if (eventName === "CursorMovedI" && this._config.getValue<boolean>("editor.completions.enabled")) {
             this._sendLanguageServiceRequest("completion-provider", eventContext)
 
             this._sendLanguageServiceRequest("signature-help", eventContext)

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -14,6 +14,7 @@ import { PluginManager } from "./../Plugins/PluginManager"
 import { CallbackCommand, CommandManager } from "./CommandManager"
 
 export const registerBuiltInCommands = (commandManager: CommandManager, pluginManager: PluginManager, neovimInstance: INeovimInstance) => {
+    const config = Config.instance()
     const commands = [
 
         // Debug
@@ -29,7 +30,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         // Menu commands
         new CallbackCommand("oni.config.openConfigJs", "Edit Oni Config", "Edit configuration file ('config.js') for ONI", () => {
             let buffer: null | IBuffer = null
-            neovimInstance.open(Config.userJsConfig)
+            neovimInstance.open(config.userJsConfig)
                 .then(() => neovimInstance.getCurrentBuffer())
                 .then((buf) => buffer = buf)
                 .then(() => buffer.getLineCount())

--- a/browser/src/Services/Formatter.ts
+++ b/browser/src/Services/Formatter.ts
@@ -13,6 +13,7 @@ import { BufferUpdates } from "./BufferUpdates"
 
 export class Formatter {
 
+    private _config = Config.instance()
     private _lastMode: string
 
     constructor(
@@ -21,7 +22,7 @@ export class Formatter {
         private _bufferUpdates: BufferUpdates,
     ) {
         this._neovimInstance.on("mode-change", (newMode: string) => {
-            if (Config.getValue<boolean>("editor.formatting.formatOnSwitchToNormalMode")
+            if (this._config.getValue<boolean>("editor.formatting.formatOnSwitchToNormalMode")
                 && newMode === "normal"
                 && this._lastMode === "insert") {
                 this.formatBuffer()

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -35,8 +35,10 @@ export class QuickOpen {
         })
     }
 
-    public show(exclude: string[]): void {
-        const overrriddenCommand = Config.getValue<string>("editor.quickOpen.execCommand")
+    public show(): void {
+        const config = Config.instance()
+        const overrriddenCommand = config.getValue<string>("editor.quickOpen.execCommand")
+        const exclude = config.getValue<string[]>("editor.exclude")
 
         UI.showPopupMenu("quickOpen", [{
             icon: "refresh fa-spin fa-fw",

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -18,10 +18,12 @@ require("./Cursor.less") // tslint:disable-line no-var-requires
 
 class CursorRenderer extends React.Component<ICursorProps, void> {
 
+    private config = Config.instance()
+
     public render(): JSX.Element {
 
-        const fontFamily = Config.getValue<string>("editor.fontFamily")
-        const fontSize = Config.getValue<string>("editor.fontSize")
+        const fontFamily = this.config.getValue<string>("editor.fontFamily")
+        const fontSize = this.config.getValue<string>("editor.fontSize")
 
         const isNormalMode = this.props.mode === "normal"
         const width = isNormalMode ? this.props.width : this.props.width / 4

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -74,6 +74,8 @@ export interface IErrorMarkerProps {
 
 export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
 
+    private config = Config.instance()
+
     public render(): JSX.Element {
 
         const positionDivStyles = {
@@ -83,7 +85,7 @@ export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
 
         let className = this.props.isActive ? "error-marker active" : "error-marker"
 
-        const errorDescription = Config.getValue<boolean>("editor.errors.slideOnFocus") ? (<div className="error">
+        const errorDescription = this.config.getValue<boolean>("editor.errors.slideOnFocus") ? (<div className="error">
             <div className="text">
                 {this.props.text}
             </div>

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -26,15 +26,16 @@ export const events = Events.events
 let defaultState = State.createDefaultState()
 
 export function setBackgroundColor(backgroundColor: string): void {
+    const config = Config.instance()
     const backgroundImageElement: HTMLElement = document.getElementsByClassName("background-image")[0] as HTMLElement
     const backgroundColorElement: HTMLElement = document.getElementsByClassName("background-cover")[0] as HTMLElement
-    const backgroundImageUrl = Config.getValue<string>("prototype.editor.backgroundImageUrl")
-    const backgroundImageSize = Config.getValue<string>("prototype.editor.backgroundImageSize") || "cover"
+    const backgroundImageUrl = config.getValue<string>("prototype.editor.backgroundImageUrl")
+    const backgroundImageSize = config.getValue<string>("prototype.editor.backgroundImageSize") || "cover"
 
     backgroundImageElement.style.backgroundImage = "url(" + backgroundImageUrl + ")"
     backgroundImageElement.style.backgroundSize = backgroundImageSize
     backgroundColorElement.style.backgroundColor = backgroundColor
-    backgroundColorElement.style.opacity = Config.getValue<string>("prototype.editor.backgroundOpacity")
+    backgroundColorElement.style.opacity = config.getValue<string>("prototype.editor.backgroundOpacity")
 }
 
 // TODO: Can we use bindaction creators for this?

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -155,6 +155,11 @@ const start = (args: string[]) => {
             UI.hideSignatureHelp()
             UI.hideQuickInfo()
         }
+
+        if (eventName === "DirChanged") {
+            instance.getCurrentWorkingDirectory()
+                .then((newDirectory) => process.chdir(newDirectory))
+        }
     })
 
     instance.on("show-popup-menu", (completions: any[]) => {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -41,22 +41,11 @@ const start = (args: string[]) => {
 
     const parsedArgs = minimist(args)
 
-    const cursorLine = Config.getValue<boolean>("editor.cursorLine")
-    const cursorColumn = Config.getValue<boolean>("editor.cursorColumn")
-    UI.setCursorLineOpacity(Config.getValue<number>("editor.cursorLineOpacity"))
-    UI.setCursorColumnOpacity(Config.getValue<number>("editor.cursorColumnOpacity"))
-
-    if (cursorLine) {
-        UI.showCursorLine()
-    }
-
-    if (cursorColumn) {
-        UI.showCursorColumn()
-    }
+    let cursorLine: boolean
+    let cursorColumn: boolean
 
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
-    remote.getCurrentWindow().setFullScreen(Config.getValue<boolean>("editor.fullScreenOnStart"))
     require("./overlay.less")
 
     let deltaRegion = new IncrementalDeltaRegionTracker()
@@ -166,11 +155,6 @@ const start = (args: string[]) => {
             UI.hideSignatureHelp()
             UI.hideQuickInfo()
         }
-
-        if (eventName === "DirChanged") {
-            instance.getCurrentWorkingDirectory()
-                .then((newDirectory) => process.chdir(newDirectory))
-        }
     })
 
     instance.on("show-popup-menu", (completions: any[]) => {
@@ -261,7 +245,29 @@ const start = (args: string[]) => {
         pendingTimeout = null
     }
 
-    instance.setFont(Config.getValue<string>("editor.fontFamily"), Config.getValue<string>("editor.fontSize"))
+    const config = Config.instance()
+
+    const configChange = () => {
+        cursorLine = config.getValue<boolean>("editor.cursorLine")
+        cursorColumn = config.getValue<boolean>("editor.cursorColumn")
+        UI.setCursorLineOpacity(config.getValue<number>("editor.cursorLineOpacity"))
+        UI.setCursorColumnOpacity(config.getValue<number>("editor.cursorColumnOpacity"))
+
+        if (cursorLine) {
+            UI.showCursorLine()
+        }
+
+        if (cursorColumn) {
+            UI.showCursorColumn()
+        }
+
+        remote.getCurrentWindow().setFullScreen(config.getValue<boolean>("editor.fullScreenOnStart"))
+        instance.setFont(config.getValue<string>("editor.fontFamily"), config.getValue<string>("editor.fontSize"))
+        updateFunction()
+    }
+    configChange() // initialize values
+    config.registerListener(configChange)
+
     instance.start(parsedArgs._)
 
     const mouse = new Mouse(editorElement, screen)
@@ -327,7 +333,7 @@ const start = (args: string[]) => {
         if (key === "<f12>") {
             commandManager.executeCommand("oni.editor.gotoDefinition", null)
         } else if (key === "<C-p>" && screen.mode === "normal") {
-            quickOpen.show(Config.getValue<string[]>("editor.exclude"))
+            quickOpen.show()
         } else if (key === "<C-P>" && screen.mode === "normal") {
             tasks.show()
         } else if (key === "<C-pageup>") {


### PR DESCRIPTION
Refactored #294 following @extr0py's suggestions.  `Config` is now a class accessed via singleton and uses `EventEmitter`.  This required changing every class that uses `Config` to fetch the singleton first.