### PR TITLE
#81, hide menubar if oni.hideMenu is set

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -44,6 +44,10 @@ class Config extends EventEmitter {
         // a custom init.vim, as that may cause problematic behavior
         "oni.useExternalPopupMenu": true,
 
+        // If true, hide Menu bar by default
+        // (can still be activated by pressing 'Alt')
+        "oni.hideMenu": false,
+
         "editor.fontSize": "14px",
         "editor.quickInfo.enabled": true,
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -259,7 +259,12 @@ const start = (args: string[]) => {
             UI.showCursorColumn()
         }
 
-        remote.getCurrentWindow().setFullScreen(config.getValue<boolean>("editor.fullScreenOnStart"))
+        const window = remote.getCurrentWindow()
+        const hideMenu: boolean = config.getValue<boolean>("oni.hideMenu")
+        window.setAutoHideMenuBar(hideMenu)
+        window.setMenuBarVisibility(!hideMenu)
+
+        window.setFullScreen(config.getValue<boolean>("editor.fullScreenOnStart"))
         instance.setFont(config.getValue<string>("editor.fontFamily"), config.getValue<string>("editor.fontSize"))
         updateFunction()
     }


### PR DESCRIPTION
As requested in #81, add option to hide menu bar.  The menu can be temporarily displayed with `Alt` when this option is set.

I believe this code should work but I wrote it on Ubuntu (with Unity) so I can't really test it out since there isn't a "menu bar" to hide.  Hopefully someone else can give it a try.  If it doesn't work, I can play with it in my Gnome 3 environment tomorrow.