### PR TITLE
Fix #305: Reduce boilerplate around actions in UI

### DIFF
--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -157,15 +157,15 @@ export class PluginManager extends EventEmitter {
             }
 
             if (!pluginResponse.error) {
-                UI.hideQuickInfo()
+                UI.Actions.hideQuickInfo()
                 setTimeout(() => {
                     if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
                         return
                     }
-                    UI.showQuickInfo(pluginResponse.payload.info, pluginResponse.payload.documentation)
+                    UI.Actions.showQuickInfo(pluginResponse.payload.info, pluginResponse.payload.documentation)
                 }, this._config.getValue<number>("editor.quickInfo.delay"))
             } else {
-                setTimeout(() => UI.hideQuickInfo())
+                setTimeout(() => UI.Actions.hideQuickInfo())
             }
         } else if (pluginResponse.type === "goto-definition") {
             if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -186,9 +186,9 @@ export class PluginManager extends EventEmitter {
                 return
             }
 
-            setTimeout(() => UI.showCompletions(pluginResponse.payload))
+            setTimeout(() => UI.Actions.showCompletions(pluginResponse.payload))
         } else if (pluginResponse.type === "completion-provider-item-selected") {
-            setTimeout(() => UI.setDetailedCompletionEntry(pluginResponse.payload.details))
+            setTimeout(() => UI.Actions.setDetailedCompletionEntry(pluginResponse.payload.details))
         } else if (pluginResponse.type === "set-errors") {
             this.emit("set-errors", pluginResponse.payload.key, pluginResponse.payload.fileName, pluginResponse.payload.errors, pluginResponse.payload.color)
         } else if (pluginResponse.type === "find-all-references") {

--- a/browser/src/Services/AutoCompletion.ts
+++ b/browser/src/Services/AutoCompletion.ts
@@ -24,7 +24,7 @@ export class AutoCompletion {
                 label: completion[0],
             }))
 
-            UI.showCompletions({
+            UI.Actions.showCompletions({
                 base: "",
                 completions: c,
             })
@@ -68,6 +68,6 @@ export class AutoCompletion {
                 return this._neovimInstance.eval(`setpos(".", [0, ${cursorRow}, ${cursorColumn + cursorOffset}, 0])`)
             })
 
-        UI.hideCompletions()
+        UI.Actions.hideCompletions()
     }
 }

--- a/browser/src/Services/AutoCompletion.ts
+++ b/browser/src/Services/AutoCompletion.ts
@@ -37,7 +37,7 @@ export class AutoCompletion {
         let originalLineLength: number
         let newLineLength: number
 
-        let completion = UI.getSelectedCompletion() || ""
+        let completion = UI.Selectors.getSelectedCompletion() || ""
         let currentBuffer: IBuffer
         this._neovimInstance.getCurrentBuffer()
             .then((buffer) => currentBuffer = buffer)

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -40,7 +40,7 @@ export class QuickOpen {
         const overrriddenCommand = config.getValue<string>("editor.quickOpen.execCommand")
         const exclude = config.getValue<string[]>("editor.exclude")
 
-        UI.showPopupMenu("quickOpen", [{
+        UI.Actions.showPopupMenu("quickOpen", [{
             icon: "refresh fa-spin fa-fw",
             label: "Loading Files...",
             detail: "",
@@ -94,6 +94,6 @@ export class QuickOpen {
                 pinned: this._seenItems.indexOf(fullPath) >= 0,
             }
         })
-        UI.showPopupMenu("quickOpen", options)
+        UI.Actions.showPopupMenu("quickOpen", options)
     }
 }

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -145,7 +145,7 @@ export class Tasks {
                 }
             })
 
-            UI.showPopupMenu("tasks", options)
+            UI.Actions.showPopupMenu("tasks", options)
         })
     }
 

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -55,18 +55,6 @@ export const setCursorPosition = (screen: IScreen) => (dispatch: Function) => {
     dispatch(_setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels, cell.character, cell.characterWidth * screen.fontWidthInPixels))
 }
 
-const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
-    type: "SET_CURSOR_POSITION",
-    payload: {
-        pixelX: cursorPixelX,
-        pixelY: cursorPixelY,
-        fontPixelWidth,
-        fontPixelHeight,
-        cursorCharacter,
-        cursorPixelWidth,
-    },
-})
-
 export const setColors = (foregroundColor: string) => (dispatch: Function, getState: Function) => {
     if (foregroundColor === getState().foregroundColor) {
         return
@@ -74,11 +62,6 @@ export const setColors = (foregroundColor: string) => (dispatch: Function, getSt
 
     dispatch(_setColors(foregroundColor))
 }
-
-const _setColors = (foregroundColor: string) => ({
-    type: "SET_COLORS",
-    payload: { foregroundColor },
-})
 
 export const setActiveWindowDimensions = (dimensions: Rectangle) => ({
     type: "SET_ACTIVE_WINDOW_DIMENSIONS",
@@ -165,14 +148,6 @@ export const setDetailedCompletionEntry = (detailedEntry: Oni.Plugin.CompletionI
     },
 })
 
-const _nextAutoCompletion = () => ({
-    type: "NEXT_AUTO_COMPLETION",
-})
-
-const _previousAutoCompletion = () => ({
-    type: "PREVIOUS_AUTO_COMPLETION",
-})
-
 export const hideCompletions = () => ({ type: "HIDE_AUTO_COMPLETION" })
 
 export const hideQuickInfo = () => ({ type: "HIDE_QUICK_INFO" })
@@ -197,4 +172,30 @@ export const setCursorColumnOpacity = (opacity: number) => ({
     payload: {
         opacity,
     },
+})
+
+const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
+    type: "SET_CURSOR_POSITION",
+    payload: {
+        pixelX: cursorPixelX,
+        pixelY: cursorPixelY,
+        fontPixelWidth,
+        fontPixelHeight,
+        cursorCharacter,
+        cursorPixelWidth,
+    },
+})
+
+const _setColors = (foregroundColor: string) => ({
+    type: "SET_COLORS",
+    payload: { foregroundColor },
+})
+
+
+const _nextAutoCompletion = () => ({
+    type: "NEXT_AUTO_COMPLETION",
+})
+
+const _previousAutoCompletion = () => ({
+    type: "PREVIOUS_AUTO_COMPLETION",
 })

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -46,7 +46,7 @@ export const hideSignatureHelp = () => ({
     type: "HIDE_SIGNATURE_HELP",
 })
 
-export const showMenu = (id: string, options: Oni.Menu.MenuOption[]) => ({
+export const showPopupMenu = (id: string, options: Oni.Menu.MenuOption[]) => ({
     type: "SHOW_MENU",
     payload: {
         id,
@@ -54,11 +54,11 @@ export const showMenu = (id: string, options: Oni.Menu.MenuOption[]) => ({
     },
 })
 
-export const hideMenu = () => ({
+export const hidePopupMenu = () => ({
     type: "HIDE_MENU",
 })
 
-export const previousMenu = () => ({
+export const previousMenuItem = () => ({
     type: "PREVIOUS_MENU",
 })
 
@@ -69,7 +69,7 @@ export const filterMenu = (filterString: string) => ({
     },
 })
 
-export const nextMenu = () => ({
+export const nextMenuItem = () => ({
     type: "NEXT_MENU",
 })
 
@@ -86,7 +86,7 @@ export const selectMenuItem = (openInSplit: boolean, index?: number) => (dispatc
 
     Events.events.emit("menu-item-selected:" + state.popupMenu.id, { selectedOption, openInSplit })
 
-    dispatch(hideMenu())
+    dispatch(hidePopupMenu())
 }
 
 export const showQuickInfo = (title: string, description: string) => ({

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -35,6 +35,19 @@ const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth
     },
 })
 
+export const setColors = (foregroundColor: string) => (dispatch: Function, getState: Function) => {
+    if (foregroundColor === getState().foregroundColor) {
+        return
+    }
+
+    dispatch(_setColors(foregroundColor))
+}
+
+const _setColors = (foregroundColor: string) => ({
+    type: "SET_COLORS",
+    payload: { foregroundColor },
+})
+
 export const setActiveWindowDimensions = (dimensions: Rectangle) => ({
     type: "SET_ACTIVE_WINDOW_DIMENSIONS",
     payload: { dimensions },
@@ -43,11 +56,6 @@ export const setActiveWindowDimensions = (dimensions: Rectangle) => ({
 export const setMode = (mode: string) => ({
     type: "SET_MODE",
     payload: { mode },
-})
-
-export const setColors = (foregroundColor: string) => ({
-    type: "SET_COLORS",
-    payload: { foregroundColor },
 })
 
 export const showSignatureHelp = (signatureHelpResult: Oni.Plugin.SignatureHelpResult) => ({

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -12,6 +12,38 @@ import { Rectangle } from "./Types"
 
 import { IScreen } from "./../Screen"
 
+import * as State from "./State"
+
+import { events } from "./Events"
+
+export const showCompletions = (result: Oni.Plugin.CompletionResult) => (dispatch: Function, getState: Function) => {
+    dispatch(_showAutoCompletion(result.base, result.completions))
+
+    if (result.completions.length > 0) {
+        emitCompletionItemSelectedEvent(getState())
+    }
+}
+
+export const previousCompletion = () => (dispatch: Function, getState: Function) => {
+    dispatch(_previousAutoCompletion())
+
+    emitCompletionItemSelectedEvent(getState())
+}
+
+export const nextCompletion = () => (dispatch: Function, getState: Function) => {
+    dispatch(_nextAutoCompletion())
+
+    emitCompletionItemSelectedEvent(getState())
+}
+
+function emitCompletionItemSelectedEvent(state: State.IState): void {
+    const autoCompletion = state.autoCompletion
+    if (autoCompletion != null) {
+        const entry = autoCompletion.entries[autoCompletion.selectedIndex]
+        events.emit(Events.CompletionItemSelectedEvent, entry)
+    }
+}
+
 export const setCursorPosition = (screen: IScreen) => (dispatch: Function) => {
     const cell = screen.getCell(screen.cursorColumn, screen.cursorRow)
 
@@ -118,7 +150,7 @@ export const showQuickInfo = (title: string, description: string) => ({
     },
 })
 
-export const showAutoCompletion = (base: string, entries: Oni.Plugin.CompletionInfo[]) => ({
+const _showAutoCompletion = (base: string, entries: Oni.Plugin.CompletionInfo[]) => ({
     type: "SHOW_AUTO_COMPLETION",
     payload: {
         base,
@@ -126,22 +158,22 @@ export const showAutoCompletion = (base: string, entries: Oni.Plugin.CompletionI
     },
 })
 
-export const setAutoCompletionDetails = (detailedEntry: Oni.Plugin.CompletionInfo) => ({
+export const setDetailedCompletionEntry = (detailedEntry: Oni.Plugin.CompletionInfo) => ({
     type: "SET_AUTO_COMPLETION_DETAILS",
     payload: {
         detailedEntry,
     },
 })
 
-export const nextAutoCompletion = () => ({
+const _nextAutoCompletion = () => ({
     type: "NEXT_AUTO_COMPLETION",
 })
 
-export const previousAutoCompletion = () => ({
+const _previousAutoCompletion = () => ({
     type: "PREVIOUS_AUTO_COMPLETION",
 })
 
-export const hideAutoCompletion = () => ({ type: "HIDE_AUTO_COMPLETION" })
+export const hideCompletions = () => ({ type: "HIDE_AUTO_COMPLETION" })
 
 export const hideQuickInfo = () => ({ type: "HIDE_QUICK_INFO" })
 

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -10,7 +10,20 @@
 import * as Events from "./Events"
 import { Rectangle } from "./Types"
 
-export const setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
+import { IScreen } from "./../Screen"
+
+export const setCursorPosition = (screen: IScreen) => (dispatch: Function) => {
+    const cell = screen.getCell(screen.cursorColumn, screen.cursorRow)
+
+    if (screen.cursorRow === screen.height - 1) {
+        dispatch(hideQuickInfo())
+        dispatch(hideSignatureHelp())
+    }
+
+    dispatch(_setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels, cell.character, cell.characterWidth * screen.fontWidthInPixels))
+}
+
+const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
     type: "SET_CURSOR_POSITION",
     payload: {
         pixelX: cursorPixelX,

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -191,7 +191,6 @@ const _setColors = (foregroundColor: string) => ({
     payload: { foregroundColor },
 })
 
-
 const _nextAutoCompletion = () => ({
     type: "NEXT_AUTO_COMPLETION",
 })

--- a/browser/src/UI/Selectors.ts
+++ b/browser/src/UI/Selectors.ts
@@ -1,0 +1,35 @@
+/**
+ * Selectors.ts
+ *
+ * Selectors are basically helper methods for operating on the State
+ * See Redux documents here fore more info:
+ * http://redux.js.org/docs/recipes/ComputingDerivedData.html
+ */
+
+import * as State from "./State"
+
+export const isPopupMenuOpen = (state: State.IState) => {
+    const popupMenu = state.popupMenu
+    return !!popupMenu
+}
+
+export const areCompletionsVisible = (state: State.IState) => {
+    const autoCompletion = state.autoCompletion
+    const entryCount = (autoCompletion && autoCompletion.entries) ? autoCompletion.entries.length : 0
+
+    if (entryCount === 0) {
+        return false
+    }
+
+    if (entryCount > 1) {
+        return true
+    }
+
+    // In the case of a single entry, should not be visible if the base is equal to the selected item
+    return autoCompletion != null && autoCompletion.base !== getSelectedCompletion(state)
+}
+
+export const getSelectedCompletion = (state: State.IState) => {
+    const autoCompletion = state.autoCompletion
+    return autoCompletion ? autoCompletion.entries[autoCompletion.selectedIndex].label : null
+}

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -16,8 +16,6 @@ import { reducer } from "./Reducer"
 
 import { InstallHelp } from "./components/InstallHelp"
 
-import { IScreen } from "./../Screen"
-
 import * as Events from "./Events"
 
 export const events = Events.events
@@ -37,24 +35,9 @@ export function setBackgroundColor(backgroundColor: string): void {
     backgroundColorElement.style.opacity = config.getValue<string>("prototype.editor.backgroundOpacity")
 }
 
-export function setCursorPosition(screen: IScreen): void {
-    const cell = screen.getCell(screen.cursorColumn, screen.cursorRow)
-
-    if (screen.cursorRow === screen.height - 1) {
-        Actions.hideQuickInfo()
-        Actions.hideSignatureHelp()
-    }
-
-    _setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels, cell.character, cell.characterWidth * screen.fontWidthInPixels)
-}
-
 export function isPopupMenuOpen(): boolean {
     const popupMenu = store.getState().popupMenu
     return !!popupMenu
-}
-
-function _setCursorPosition(cursorPixelX: number, cursorPixelY: number, fontPixelWidth: number, fontPixelHeight: number, cursorCharacter: string, cursorPixelWidth: number): void {
-    store.dispatch(ActionCreators.setCursorPosition(cursorPixelX, cursorPixelY, fontPixelWidth, fontPixelHeight, cursorCharacter, cursorPixelWidth))
 }
 
 export function setColors(foregroundColor: string): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -42,10 +42,15 @@ export function setCursorPosition(screen: IScreen): void {
 
     if (screen.cursorRow === screen.height - 1) {
         hideQuickInfo()
-        hideSignatureHelp()
+        Actions.hideSignatureHelp()
     }
 
     _setCursorPosition(screen.cursorColumn * screen.fontWidthInPixels, screen.cursorRow * screen.fontHeightInPixels, screen.fontWidthInPixels, screen.fontHeightInPixels, cell.character, cell.characterWidth * screen.fontWidthInPixels)
+}
+
+export function isPopupMenuOpen(): boolean {
+    const popupMenu = store.getState().popupMenu
+    return !!popupMenu
 }
 
 function _setCursorPosition(cursorPixelX: number, cursorPixelY: number, fontPixelWidth: number, fontPixelHeight: number, cursorCharacter: string, cursorPixelWidth: number): void {
@@ -58,31 +63,6 @@ export function setColors(foregroundColor: string): void {
     }
 
     store.dispatch(ActionCreators.setColors(foregroundColor))
-}
-
-export function showPopupMenu(id: string, options: Oni.Menu.MenuOption[]): void {
-    store.dispatch(ActionCreators.showMenu(id, options))
-}
-
-export function hidePopupMenu(): void {
-    store.dispatch(ActionCreators.hideMenu())
-}
-
-export function isPopupMenuOpen(): boolean {
-    const popupMenu = store.getState().popupMenu
-    return !!popupMenu
-}
-
-export function nextPopupMenuItem(): void {
-    store.dispatch(ActionCreators.nextMenu())
-}
-
-export function previousPopupMenuItem(): void {
-    store.dispatch(ActionCreators.previousMenu())
-}
-
-export function selectPopupMenuItem(openInSplit: boolean, menuItemIndex?: number): void {
-    store.dispatch(ActionCreators.selectMenuItem(openInSplit, menuItemIndex))
 }
 
 export function showQuickInfo(title: string, description: string): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 
 import { Provider } from "react-redux"
-import { applyMiddleware, compose, createStore } from "redux"
+import { applyMiddleware, compose, createStore, bindActionCreators } from "redux"
 import thunk from "redux-thunk"
 
 import * as Config from "./../Config"
@@ -182,16 +182,11 @@ const enhancer = composeEnhancers(
 
 const store = createStore(reducer, defaultState, enhancer)
 
+export const Actions = bindActionCreators(ActionCreators as any, store.dispatch)
+
+
 export function init(): void {
     render(defaultState)
-}
-
-export function showCursorLine(): void {
-    store.dispatch(ActionCreators.showCursorLine())
-}
-
-export function hideCursorLine(): void {
-    store.dispatch(ActionCreators.hideCursorLine())
 }
 
 export function showCursorColumn(): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -17,6 +17,7 @@ import { reducer } from "./Reducer"
 import { InstallHelp } from "./components/InstallHelp"
 
 import * as Events from "./Events"
+import * as UnboundSelectors from "./Selectors"
 
 export const events = Events.events
 
@@ -35,32 +36,6 @@ export function setBackgroundColor(backgroundColor: string): void {
     backgroundColorElement.style.opacity = config.getValue<string>("prototype.editor.backgroundOpacity")
 }
 
-export function isPopupMenuOpen(): boolean {
-    const popupMenu = store.getState().popupMenu
-    return !!popupMenu
-}
-
-export function areCompletionsVisible(): boolean {
-    const autoCompletion = store.getState().autoCompletion
-    const entryCount = (autoCompletion && autoCompletion.entries) ? autoCompletion.entries.length : 0
-
-    if (entryCount === 0) {
-        return false
-    }
-
-    if (entryCount > 1) {
-        return true
-    }
-
-    // In the case of a single entry, should not be visible if the base is equal to the selected item
-    return autoCompletion != null && autoCompletion.base !== getSelectedCompletion()
-}
-
-export function getSelectedCompletion(): null | string {
-    const autoCompletion = store.getState().autoCompletion
-    return autoCompletion ? autoCompletion.entries[autoCompletion.selectedIndex].label : null
-}
-
 export function showNeovimInstallHelp(): void {
     const element = document.getElementById("overlay-ui")
     ReactDOM.render(<InstallHelp />, element)
@@ -74,6 +49,13 @@ const enhancer = composeEnhancers(
 const store = createStore(reducer, defaultState, enhancer)
 
 export const Actions = bindActionCreators(ActionCreators as any, store.dispatch)
+
+// TODO: Is there a helper utility like `bindActionCreators`, but for selectors?
+export const Selectors = {
+    isPopupMenuOpen: () => UnboundSelectors.isPopupMenuOpen(store.getState()),
+    areCompletionsVisible: () => UnboundSelectors.areCompletionsVisible(store.getState()),
+    getSelectedCompletion: () => UnboundSelectors.getSelectedCompletion(store.getState())
+}
 
 export function init(): void {
     render(defaultState)

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -54,7 +54,7 @@ export const Actions = bindActionCreators(ActionCreators as any, store.dispatch)
 export const Selectors = {
     isPopupMenuOpen: () => UnboundSelectors.isPopupMenuOpen(store.getState()),
     areCompletionsVisible: () => UnboundSelectors.areCompletionsVisible(store.getState()),
-    getSelectedCompletion: () => UnboundSelectors.getSelectedCompletion(store.getState())
+    getSelectedCompletion: () => UnboundSelectors.getSelectedCompletion(store.getState()),
 }
 
 export function init(): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -149,14 +149,6 @@ export function init(): void {
     render(defaultState)
 }
 
-export function setCursorLineOpacity(opacity: number): void {
-    store.dispatch(ActionCreators.setCursorLineOpacity(opacity))
-}
-
-export function setCursorColumnOpacity(opacity: number): void {
-    store.dispatch(ActionCreators.setCursorColumnOpacity(opacity))
-}
-
 function render(_state: State.IState): void {
     const element = document.getElementById("overlay-ui")
     ReactDOM.render(

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -60,14 +60,6 @@ export function setColors(foregroundColor: string): void {
     store.dispatch(ActionCreators.setColors(foregroundColor))
 }
 
-export function showSignatureHelp(help: Oni.Plugin.SignatureHelpResult): void {
-    store.dispatch(ActionCreators.showSignatureHelp(help))
-}
-
-export function hideSignatureHelp(): void {
-    store.dispatch(ActionCreators.hideSignatureHelp())
-}
-
 export function showPopupMenu(id: string, options: Oni.Menu.MenuOption[]): void {
     store.dispatch(ActionCreators.showMenu(id, options))
 }

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -61,43 +61,6 @@ export function getSelectedCompletion(): null | string {
     return autoCompletion ? autoCompletion.entries[autoCompletion.selectedIndex].label : null
 }
 
-export function showCompletions(result: Oni.Plugin.CompletionResult): void {
-    store.dispatch(ActionCreators.showAutoCompletion(result.base, result.completions))
-
-    // TODO: Figure out why this isn't working
-    if (result.completions.length > 0) {
-        emitCompletionItemSelectedEvent()
-    }
-}
-
-export function setDetailedCompletionEntry(detailedEntry: Oni.Plugin.CompletionInfo): void {
-    store.dispatch(ActionCreators.setAutoCompletionDetails(detailedEntry))
-}
-
-export function hideCompletions(): void {
-    store.dispatch(ActionCreators.hideAutoCompletion())
-}
-
-export function nextCompletion(): void {
-    store.dispatch(ActionCreators.nextAutoCompletion())
-
-    emitCompletionItemSelectedEvent()
-}
-
-export function previousCompletion(): void {
-    store.dispatch(ActionCreators.previousAutoCompletion())
-
-    emitCompletionItemSelectedEvent()
-}
-
-function emitCompletionItemSelectedEvent(): void {
-    const autoCompletion = store.getState().autoCompletion
-    if (autoCompletion != null) {
-        const entry = autoCompletion.entries[autoCompletion.selectedIndex]
-        events.emit(Events.CompletionItemSelectedEvent, entry)
-    }
-}
-
 export function showNeovimInstallHelp(): void {
     const element = document.getElementById("overlay-ui")
     ReactDOM.render(<InstallHelp />, element)

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -9,7 +9,6 @@ import * as Config from "./../Config"
 
 import { RootComponent } from "./RootComponent"
 import * as State from "./State"
-import { Rectangle } from "./Types"
 
 // import * as Actions from "./Actions"
 import * as ActionCreators from "./ActionCreators"
@@ -38,11 +37,6 @@ export function setBackgroundColor(backgroundColor: string): void {
     backgroundColorElement.style.opacity = config.getValue<string>("prototype.editor.backgroundOpacity")
 }
 
-// TODO: Can we use bindaction creators for this?
-export function setActiveWindowDimensionsChanged(dimensions: Rectangle) {
-    store.dispatch(ActionCreators.setActiveWindowDimensions(dimensions))
-}
-
 export function setCursorPosition(screen: IScreen): void {
     const cell = screen.getCell(screen.cursorColumn, screen.cursorRow)
 
@@ -56,11 +50,6 @@ export function setCursorPosition(screen: IScreen): void {
 
 function _setCursorPosition(cursorPixelX: number, cursorPixelY: number, fontPixelWidth: number, fontPixelHeight: number, cursorCharacter: string, cursorPixelWidth: number): void {
     store.dispatch(ActionCreators.setCursorPosition(cursorPixelX, cursorPixelY, fontPixelWidth, fontPixelHeight, cursorCharacter, cursorPixelWidth))
-}
-
-// TODO: Can we use bindaction creators for this?
-export function setMode(mode: string): void {
-    store.dispatch(ActionCreators.setMode(mode))
 }
 
 export function setColors(foregroundColor: string): void {
@@ -184,17 +173,8 @@ const store = createStore(reducer, defaultState, enhancer)
 
 export const Actions = bindActionCreators(ActionCreators as any, store.dispatch)
 
-
 export function init(): void {
     render(defaultState)
-}
-
-export function showCursorColumn(): void {
-    store.dispatch(ActionCreators.showCursorColumn())
-}
-
-export function hideCursorColumn(): void {
-    store.dispatch(ActionCreators.hideCursorColumn())
 }
 
 export function setCursorLineOpacity(opacity: number): void {

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -40,14 +40,6 @@ export function isPopupMenuOpen(): boolean {
     return !!popupMenu
 }
 
-export function setColors(foregroundColor: string): void {
-    if (foregroundColor === store.getState().foregroundColor) {
-        return
-    }
-
-    store.dispatch(ActionCreators.setColors(foregroundColor))
-}
-
 export function areCompletionsVisible(): boolean {
     const autoCompletion = store.getState().autoCompletion
     const entryCount = (autoCompletion && autoCompletion.entries) ? autoCompletion.entries.length : 0

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 
 import { Provider } from "react-redux"
-import { applyMiddleware, compose, createStore, bindActionCreators } from "redux"
+import { applyMiddleware, bindActionCreators, compose, createStore } from "redux"
 import thunk from "redux-thunk"
 
 import * as Config from "./../Config"
@@ -41,7 +41,7 @@ export function setCursorPosition(screen: IScreen): void {
     const cell = screen.getCell(screen.cursorColumn, screen.cursorRow)
 
     if (screen.cursorRow === screen.height - 1) {
-        hideQuickInfo()
+        Actions.hideQuickInfo()
         Actions.hideSignatureHelp()
     }
 
@@ -63,14 +63,6 @@ export function setColors(foregroundColor: string): void {
     }
 
     store.dispatch(ActionCreators.setColors(foregroundColor))
-}
-
-export function showQuickInfo(title: string, description: string): void {
-    store.dispatch(ActionCreators.showQuickInfo(title, description))
-}
-
-export function hideQuickInfo(): void {
-    store.dispatch(ActionCreators.hideQuickInfo())
 }
 
 export function areCompletionsVisible(): boolean {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -106,9 +106,9 @@ const start = (args: string[]) => {
 
     pluginManager.on("signature-help-response", (err: string, signatureHelp: any) => { // FIXME: setup Oni import
         if (err) {
-            UI.hideSignatureHelp()
+            UI.Actions.hideSignatureHelp()
         } else {
-            UI.showSignatureHelp(signatureHelp)
+            UI.Actions.showSignatureHelp(signatureHelp)
         }
     })
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -183,7 +183,7 @@ const start = (args: string[]) => {
         renderer.onAction(action)
         screen.dispatch(action)
 
-        UI.setColors(screen.foregroundColor)
+        UI.Actions.setColors(screen.foregroundColor)
 
         if (!pendingTimeout) {
             pendingTimeout = setTimeout(updateFunction, 0) as any // FIXME: null

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -248,8 +248,8 @@ const start = (args: string[]) => {
     const configChange = () => {
         cursorLine = config.getValue<boolean>("editor.cursorLine")
         cursorColumn = config.getValue<boolean>("editor.cursorColumn")
-        UI.setCursorLineOpacity(config.getValue<number>("editor.cursorLineOpacity"))
-        UI.setCursorColumnOpacity(config.getValue<number>("editor.cursorColumnOpacity"))
+        UI.Actions.setCursorLineOpacity(config.getValue<number>("editor.cursorLineOpacity"))
+        UI.Actions.setCursorColumnOpacity(config.getValue<number>("editor.cursorColumnOpacity"))
 
         if (cursorLine) {
             UI.Actions.showCursorLine()

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -158,7 +158,7 @@ const start = (args: string[]) => {
             UI.hideCompletions()
             UI.Actions.hidePopupMenu()
             UI.Actions.hideSignatureHelp()
-            UI.hideQuickInfo()
+            UI.Actions.hideQuickInfo()
         }
 
         if (eventName === "DirChanged") {
@@ -203,7 +203,7 @@ const start = (args: string[]) => {
             UI.hideCompletions()
             UI.Actions.hideSignatureHelp()
         } else if (newMode === "insert") {
-            UI.hideQuickInfo()
+            UI.Actions.hideQuickInfo()
             if (cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
                 UI.Actions.showCursorLine()
             }
@@ -214,7 +214,7 @@ const start = (args: string[]) => {
             UI.Actions.hideCursorColumn() // TODO: cleaner way to hide and unhide?
             UI.Actions.hideCursorLine()
             UI.hideCompletions()
-            UI.hideQuickInfo()
+            UI.Actions.hideQuickInfo()
 
         }
     })

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -288,7 +288,7 @@ const start = (args: string[]) => {
             return
         }
 
-        if (UI.isPopupMenuOpen()) {
+        if (UI.Selectors.isPopupMenuOpen()) {
             if (key === "<esc>") {
                 UI.Actions.hidePopupMenu()
             } else if (key === "<enter>") {
@@ -304,7 +304,7 @@ const start = (args: string[]) => {
             return
         }
 
-        if (UI.areCompletionsVisible()) {
+        if (UI.Selectors.areCompletionsVisible()) {
 
             if (key === "<enter>") {
                 autoCompletion.complete()

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -221,7 +221,7 @@ const start = (args: string[]) => {
 
     const renderFunction = () => {
         if (pendingTimeout) {
-            UI.setCursorPosition(screen)
+            UI.Actions.setCursorPosition(screen)
         }
 
         renderer.update(screen, deltaRegion)
@@ -235,7 +235,7 @@ const start = (args: string[]) => {
 
     const updateFunction = () => {
         // TODO: Move cursor to component
-        UI.setCursorPosition(screen)
+        UI.Actions.setCursorPosition(screen)
 
         UI.setBackgroundColor(screen.backgroundColor)
 
@@ -307,7 +307,6 @@ const start = (args: string[]) => {
             } else if (key === "<C-n>") {
                 UI.nextCompletion()
                 return
-
             } else if (key === "<C-p>") {
                 UI.previousCompletion()
                 return

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -155,7 +155,7 @@ const start = (args: string[]) => {
 
         if (eventName === "BufEnter") {
             // TODO: More convenient way to hide all UI?
-            UI.hideCompletions()
+            UI.Actions.hideCompletions()
             UI.Actions.hidePopupMenu()
             UI.Actions.hideSignatureHelp()
             UI.Actions.hideQuickInfo()
@@ -200,7 +200,7 @@ const start = (args: string[]) => {
             if (cursorColumn) {
                 UI.Actions.showCursorColumn()
             }
-            UI.hideCompletions()
+            UI.Actions.hideCompletions()
             UI.Actions.hideSignatureHelp()
         } else if (newMode === "insert") {
             UI.Actions.hideQuickInfo()
@@ -213,7 +213,7 @@ const start = (args: string[]) => {
         } else if (newMode === "cmdline") {
             UI.Actions.hideCursorColumn() // TODO: cleaner way to hide and unhide?
             UI.Actions.hideCursorLine()
-            UI.hideCompletions()
+            UI.Actions.hideCompletions()
             UI.Actions.hideQuickInfo()
 
         }
@@ -276,7 +276,7 @@ const start = (args: string[]) => {
     const mouse = new Mouse(editorElement, screen)
 
     mouse.on("mouse", (mouseInput: string) => {
-        UI.hideCompletions()
+        UI.Actions.hideCompletions()
         instance.input(mouseInput)
     })
 
@@ -310,10 +310,10 @@ const start = (args: string[]) => {
                 autoCompletion.complete()
                 return
             } else if (key === "<C-n>") {
-                UI.nextCompletion()
+                UI.Actions.nextCompletion()
                 return
             } else if (key === "<C-p>") {
-                UI.previousCompletion()
+                UI.Actions.previousCompletion()
                 return
             }
         }

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -156,8 +156,8 @@ const start = (args: string[]) => {
         if (eventName === "BufEnter") {
             // TODO: More convenient way to hide all UI?
             UI.hideCompletions()
-            UI.hidePopupMenu()
-            UI.hideSignatureHelp()
+            UI.Actions.hidePopupMenu()
+            UI.Actions.hideSignatureHelp()
             UI.hideQuickInfo()
         }
 
@@ -201,7 +201,7 @@ const start = (args: string[]) => {
                 UI.Actions.showCursorColumn()
             }
             UI.hideCompletions()
-            UI.hideSignatureHelp()
+            UI.Actions.hideSignatureHelp()
         } else if (newMode === "insert") {
             UI.hideQuickInfo()
             if (cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
@@ -285,15 +285,15 @@ const start = (args: string[]) => {
 
         if (UI.isPopupMenuOpen()) {
             if (key === "<esc>") {
-                UI.hidePopupMenu()
+                UI.Actions.hidePopupMenu()
             } else if (key === "<enter>") {
-                UI.selectPopupMenuItem(false)
+                UI.Actions.selectPopupMenuItem(false)
             } else if (key === "<C-v>") {
-                UI.selectPopupMenuItem(true)
+                UI.Actions.selectPopupMenuItem(true)
             } else if (key === "<C-n>") {
-                UI.nextPopupMenuItem()
+                UI.Actions.nextPopupMenuItem()
             } else if (key === "<C-p>") {
-                UI.previousPopupMenuItem()
+                UI.Actions.previousPopupMenuItem()
             }
 
             return

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -102,7 +102,7 @@ const start = (args: string[]) => {
     overlayManager.addOverlay("live-eval", liveEvaluationOverlay)
     overlayManager.addOverlay("scrollbar", scrollbarOverlay)
 
-    overlayManager.on("current-window-size-changed", (dimensionsInPixels: Rectangle) => UI.setActiveWindowDimensionsChanged(dimensionsInPixels))
+    overlayManager.on("current-window-size-changed", (dimensionsInPixels: Rectangle) => UI.Actions.setActiveWindowDimensionsChanged(dimensionsInPixels))
 
     pluginManager.on("signature-help-response", (err: string, signatureHelp: any) => { // FIXME: setup Oni import
         if (err) {
@@ -191,7 +191,7 @@ const start = (args: string[]) => {
     })
 
     instance.on("mode-change", (newMode: string) => {
-        UI.setMode(newMode)
+        UI.Actions.setMode(newMode)
 
         if (newMode === "normal") {
             if (cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
@@ -211,7 +211,7 @@ const start = (args: string[]) => {
                 UI.Actions.showCursorColumn()
             }
         } else if (newMode === "cmdline") {
-            UI.hideCursorColumn() // TODO: cleaner way to hide and unhide?
+            UI.Actions.hideCursorColumn() // TODO: cleaner way to hide and unhide?
             UI.Actions.hideCursorLine()
             UI.hideCompletions()
             UI.hideQuickInfo()

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -287,13 +287,13 @@ const start = (args: string[]) => {
             if (key === "<esc>") {
                 UI.Actions.hidePopupMenu()
             } else if (key === "<enter>") {
-                UI.Actions.selectPopupMenuItem(false)
+                UI.Actions.selectMenuItem(false)
             } else if (key === "<C-v>") {
-                UI.Actions.selectPopupMenuItem(true)
+                UI.Actions.selectMenuItem(true)
             } else if (key === "<C-n>") {
-                UI.Actions.nextPopupMenuItem()
+                UI.Actions.nextMenuItem()
             } else if (key === "<C-p>") {
-                UI.Actions.previousPopupMenuItem()
+                UI.Actions.previousMenuItem()
             }
 
             return

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -195,24 +195,24 @@ const start = (args: string[]) => {
 
         if (newMode === "normal") {
             if (cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
-                UI.showCursorLine()
+                UI.Actions.showCursorLine()
             }
             if (cursorColumn) {
-                UI.showCursorColumn()
+                UI.Actions.showCursorColumn()
             }
             UI.hideCompletions()
             UI.hideSignatureHelp()
         } else if (newMode === "insert") {
             UI.hideQuickInfo()
             if (cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
-                UI.showCursorLine()
+                UI.Actions.showCursorLine()
             }
             if (cursorColumn) {
-                UI.showCursorColumn()
+                UI.Actions.showCursorColumn()
             }
         } else if (newMode === "cmdline") {
             UI.hideCursorColumn() // TODO: cleaner way to hide and unhide?
-            UI.hideCursorLine()
+            UI.Actions.hideCursorLine()
             UI.hideCompletions()
             UI.hideQuickInfo()
 
@@ -252,11 +252,11 @@ const start = (args: string[]) => {
         UI.setCursorColumnOpacity(config.getValue<number>("editor.cursorColumnOpacity"))
 
         if (cursorLine) {
-            UI.showCursorLine()
+            UI.Actions.showCursorLine()
         }
 
         if (cursorColumn) {
-            UI.showCursorColumn()
+            UI.Actions.showCursorColumn()
         }
 
         remote.getCurrentWindow().setFullScreen(config.getValue<boolean>("editor.fullScreenOnStart"))


### PR DESCRIPTION
- Use the `bindActionCreators` utility from Redux to avoid having to redefine the same function multiple times