### PR TITLE
Fix #310 - Cursor in wrong position after completion

### DIFF
--- a/browser/src/Services/AutoCompletion.ts
+++ b/browser/src/Services/AutoCompletion.ts
@@ -65,7 +65,7 @@ export class AutoCompletion {
                 const cursorOffset = newLineLength - originalLineLength
 
                 // Set cursor position after the word
-                return this._neovimInstance.eval(`setpos(".", [0, ${cursorRow}, ${cursorColumn + cursorOffset} + 2, 0])`)
+                return this._neovimInstance.eval(`setpos(".", [0, ${cursorRow}, ${cursorColumn + cursorOffset}, 0])`)
             })
 
         UI.hideCompletions()


### PR DESCRIPTION
Fix #310 - the cursor ends up in the wrong position after completion