### PR TITLE
BREAKING CHANGE, Use consistent naming convention for config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,12 @@ A few interesting configuration options to set:
 - `oni.audio.bellUrl` - Set a custom sound effect for the `bell` (`:help bell`). The value should be an _absolute path_ to a supported audio file, such as a WAV file.
 - `oni.useDefaultConfig` - ONI comes with an opinionated default set of plugins for a predictable out-of-box experience. This will be great for newcomes to ONI or Vim, but for Vim/Neovim veterans, this will likely conflict. Set this to `false` to avoid loading the default config, and to load settings from `init.vim` instead (If this is false, it implies `oni.loadInitVim` is true)
 - `oni.loadInitVim` - This determines whether the user's `init.vim` is loaded. Use caution when setting this to `true` and setting `oni.useDefaultConfig` to true, as there could be conflicts with the default configuration.
+- `oni.exclude` - Glob pattern of files to exclude from Fuzzy Finder (Ctrl-P).  Defaults to `["**/node_modules/**"]`
+- `oni.hideMenu` - (default: `false`) If true, hide menu bar.  When hidden, menu bar can still be displayed with `Alt`.
 - `editor.fontSize` - Font size
 - `editor.fontFamily` - Font family
-- `prototype.editor.backgroundImageUrl` - specific a custom background image
-- `prototype.editor.backgroundImageSize` - specific a custom background size (cover, contain)
+- `editor.backgroundImageUrl` - specific a custom background image
+- `editor.backgroundImageSize` - specific a custom background size (cover, contain)
 
 See the `Config.ts` file for other interesting values to set.
 

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -12,19 +12,13 @@ class Config extends EventEmitter {
     private DefaultConfig: any = {
         // Debug settings
         "debug.incrementalRenderRegions": false,
+        "debug.maxCellsToRender": 12000,
 
-        // Prototype settings
-        "prototype.editor.backgroundOpacity": 0.7,
-        "prototype.editor.backgroundImageUrl": "images/background.png",
-        "prototype.editor.backgroundImageSize": "initial",
-
-        "prototype.editor.maxCellsToRender": 12000,
+        // Production settings
 
         // Bell sound effect to use
         // See `:help bell` for instances where the bell sound would be used
         "oni.audio.bellUrl": path.join(__dirname, "audio", "beep.wav"),
-
-        // Production settings
 
         // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
         // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
@@ -48,16 +42,25 @@ class Config extends EventEmitter {
         // (can still be activated by pressing 'Alt')
         "oni.hideMenu": false,
 
-        "editor.fontSize": "14px",
-        "editor.quickInfo.enabled": true,
+        // glob pattern of files to exclude from fuzzy finder (Ctrl-P)
+        "oni.exclude": ["**/node_modules/**"],
 
+        // Editor settings
+
+        "editor.backgroundOpacity": 0.7,
+        "editor.backgroundImageUrl": "images/background.png",
+        "editor.backgroundImageSize": "initial",
+
+        "editor.quickInfo.enabled": true,
         // Delay (in ms) for showing QuickInfo, when the cursor is on a term
         "editor.quickInfo.delay": 500,
 
         "editor.completions.enabled": true,
         "editor.errors.slideOnFocus": true,
         "editor.formatting.formatOnSwitchToNormalMode": false, // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
-        "editor.exclude": ["**/node_modules/**"],
+
+        "editor.fontSize": "14px",
+        // "editor.fontFamily" is platform-specific
 
         // Command to list files for 'quick open'
         // For example, to use 'ag': ag --nocolor -l .
@@ -66,6 +69,7 @@ class Config extends EventEmitter {
         //
         // IE, Windows:
         // "editor.quickOpen.execCommand": "dir /s /b"
+
         "editor.fullScreenOnStart" : false,
 
         "editor.cursorLine": true,

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -38,7 +38,7 @@ export class QuickOpen {
     public show(): void {
         const config = Config.instance()
         const overrriddenCommand = config.getValue<string>("editor.quickOpen.execCommand")
-        const exclude = config.getValue<string[]>("editor.exclude")
+        const exclude = config.getValue<string[]>("oni.exclude")
 
         UI.Actions.showPopupMenu("quickOpen", [{
             icon: "refresh fa-spin fa-fw",

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -27,13 +27,13 @@ export function setBackgroundColor(backgroundColor: string): void {
     const config = Config.instance()
     const backgroundImageElement: HTMLElement = document.getElementsByClassName("background-image")[0] as HTMLElement
     const backgroundColorElement: HTMLElement = document.getElementsByClassName("background-cover")[0] as HTMLElement
-    const backgroundImageUrl = config.getValue<string>("prototype.editor.backgroundImageUrl")
-    const backgroundImageSize = config.getValue<string>("prototype.editor.backgroundImageSize") || "cover"
+    const backgroundImageUrl = config.getValue<string>("editor.backgroundImageUrl")
+    const backgroundImageSize = config.getValue<string>("editor.backgroundImageSize") || "cover"
 
     backgroundImageElement.style.backgroundImage = "url(" + backgroundImageUrl + ")"
     backgroundImageElement.style.backgroundSize = backgroundImageSize
     backgroundColorElement.style.backgroundColor = backgroundColor
-    backgroundColorElement.style.opacity = config.getValue<string>("prototype.editor.backgroundOpacity")
+    backgroundColorElement.style.opacity = config.getValue<string>("editor.backgroundOpacity")
 }
 
 export function showNeovimInstallHelp(): void {


### PR DESCRIPTION
As discussed in Gitter, I felt the config options should be more consistent in the namespaces used.  For now, the current convention is:

`debug` - internal properties no user should care about.  Currently just `incrementalRenderRegions` and `maxCellsToRender`, though I couldn't find any evidence `maxCellsToRender` is still being used.

`oni` - properties that affect **Oni** features, mostly unrelated to Neovim.  Things like menus, fuzzy finder, etc.

`editor` - properties that affect the viewable "neovim area" even though they don't affect Neovim itself.  Things like highlights, colors, etc.  This includes the background settings, which had been under a `prototype` namespace.

I've updated the README.md accordingly.  Let me know if you disagree with any of the changes I made though.