### PR TITLE
Tweak error marker css

### DIFF
--- a/browser/src/UI/components/Error.less
+++ b/browser/src/UI/components/Error.less
@@ -27,11 +27,6 @@
         position: absolute;
         left: 200px;
         background-color: rgb(60, 60, 60);
-
-        display: flex;
-
-        align-items: center;
-        height: 100%;
         width: 100%;
 
         .text {
@@ -40,10 +35,9 @@
             text-overflow: ellipsis;
             overflow: hidden;
             text-align: center;
-
-            justify-content: center;
-            align-items: center;
-            padding: 8px;
+            padding-right: @errorMarkerSize;
+            padding-top: 3px;
+            padding-bottom: 2px;
         }
     }
 

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -80,7 +80,6 @@ export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
 
         const positionDivStyles = {
             top: this.props.y.toString() + "px",
-            height: (padding + this.props.height).toString() + "px",
         }
 
         let className = this.props.isActive ? "error-marker active" : "error-marker"


### PR DESCRIPTION
The error marker looks great for small messages but didn't look right when the message got long.

This Pull Request changes this:
![error](https://cloud.githubusercontent.com/assets/817509/24513729/346933d4-152f-11e7-9f9c-5f6f8e20f6ee.png)
to this:
![error_new](https://cloud.githubusercontent.com/assets/817509/24513733/383150aa-152f-11e7-990c-f186de4bca01.png)

I also deleted a couple CSS rules that didn't seem to be having any effect.  I deleted them and didn't notice any change in behavior but if they were there for a purpose let me know and I'll put them back.