### PR TITLE
Fix #332, hide 'Open Neovim Config' menu unless oni.loadInitVim is true

### DIFF
--- a/Menu.js
+++ b/Menu.js
@@ -5,7 +5,7 @@ const os = require('os')
 const { Menu, app, shell, dialog } = electron;
 
 
-const buildMenu = (mainWindow) => {
+const buildMenu = (mainWindow, loadInit) => {
     let menu = []
 
     // On Windows, both the forward slash `/` and the backward slash `\` are accepted as path delimiters.
@@ -22,6 +22,24 @@ const buildMenu = (mainWindow) => {
             return
 
         files.forEach((fileName) => executeVimCommand(`${command} ${normalizePath(fileName)}`))
+    }
+
+    let preferences = {
+        label: 'Preferences',
+        submenu: [
+            {
+                label: "Edit Oni config",
+                click: () => executeOniCommand("oni.config.openConfigJs")
+            },
+        ]
+    }
+
+    if (loadInit) {
+        preferences.submenu.push(
+        {
+            label: "Edit Neovim config",
+            click: () => executeOniCommand("oni.config.openInitVim")
+        })
     }
 
     let firstMenu = os.platform() == "win32" ? 'File' : 'Oni';
@@ -63,19 +81,7 @@ const buildMenu = (mainWindow) => {
             {
                 type: 'separator'
             },
-            {
-                label: 'Preferences',
-                submenu: [
-                {
-                    label: "Edit Oni config",
-                    click: () => executeOniCommand("oni.config.openConfigJs")
-                },
-                {
-                    label: "Edit Neovim config",
-                    click: () => executeOniCommand("oni.config.openInitVim")
-                }
-                ]
-            },
+            preferences,
             {
                 type: 'separator'
             },

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -40,6 +40,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
                             "module.exports = {",
                             "  //add custom config here, such as",
                             "  //\"oni.useDefaultConfig\": true,",
+                            "  //\"oni.loadInitVim\": false,",
                             "  //\"editor.fontSize\": \"14px\",",
                             "  //\"editor.fontFamily\": \"Monaco\"",
                             "}",

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -46,6 +46,7 @@ const start = (args: string[]) => {
 
     let cursorLine: boolean
     let cursorColumn: boolean
+    let loadInitVim: boolean = false
 
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
@@ -263,6 +264,13 @@ const start = (args: string[]) => {
         const hideMenu: boolean = config.getValue<boolean>("oni.hideMenu")
         window.setAutoHideMenuBar(hideMenu)
         window.setMenuBarVisibility(!hideMenu)
+
+        const loadInit: boolean = config.getValue<boolean>("oni.loadInitVim")
+        if (loadInit !== loadInitVim) {
+            ipcRenderer.send("rebuild-menu", loadInit)
+            // don't rebuild menu unless oni.loadInitVim actually changed
+            loadInitVim = loadInit
+        }
 
         window.setFullScreen(config.getValue<boolean>("editor.fullScreenOnStart"))
         instance.setFont(config.getValue<string>("editor.fontFamily"), config.getValue<string>("editor.fontSize"))

--- a/main.js
+++ b/main.js
@@ -60,20 +60,17 @@ function createWindow(commandLineArguments, workingDirectory) {
     // Create the browser window.
     let mainWindow = new BrowserWindow({ width: 800, height: 600, icon: path.join(__dirname, "images", "Oni_128.png") })
 
-    const menu = buildMenu(mainWindow)
-    if (process.platform === 'darwin') {
-        //all osx windows share the same menu
-        Menu.setApplicationMenu(menu)
-    } else {
-        //on windows and linux, set menu per window
-        mainWindow.setMenu(menu);
-    }
+    updateMenu(mainWindow, false)
 
     mainWindow.webContents.on("did-finish-load", () => {
         mainWindow.webContents.send("init", {
             args: commandLineArguments,
             workingDirectory: workingDirectory
         })
+    })
+
+    ipcMain.on('rebuild-menu', function(_evt, loadInit) {
+        updateMenu(mainWindow, loadInit)
     })
 
     // and load the index.html of the app.
@@ -123,6 +120,17 @@ app.on('activate', function() {
         createWindow()
     }
 })
+
+function updateMenu(mainWindow, loadInit) {
+    const menu = buildMenu(mainWindow, loadInit)
+    if (process.platform === 'darwin') {
+        //all osx windows share the same menu
+        Menu.setApplicationMenu(menu)
+    } else {
+        //on windows and linux, set menu per window
+        mainWindow.setMenu(menu);
+    }
+}
 
 function focusNextInstance(direction) {
     const currentFocusedWindows = windows.filter(f => f.isFocused())


### PR DESCRIPTION
As discussed in #332, hide the `Open Neovim Config` menu item unless `oni.loadInitVim` is true.  This is because we were trying to open `$MYVIMRC` and that environment variable is not set unless `init.vim` was loaded.

Note that because of https://github.com/electron/electron/issues/528 we can't just add/remove that menu item; we have to rebuild the entire `Menu` object to modify it.  I added some logic to only rebuild the menu if `oni.loadInitVim` changes, rather than rebuilding every time the user saves `config.js`.  However, this does mean we build the menu once as Electron starts and then (if `oni.loadInitVim` is true) build the menu again when the config is done loading.

Also, I had mentioned I wanted to add some comment to the default `config.js` telling users this menu item would exist.  I ultimately decided against it.  The existence of this menu item wouldn't affect their decision to enable `oni.loadInitVim` or not, it's just a nice-to-have feature.