### PR TITLE
Fix #342, issue with first launch when ~/.oni doesn't exist

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -110,7 +110,7 @@ class Config extends EventEmitter {
         // and continue to fire when file references are swapped out.
         // Unfortunately, this also means the 'change' event fires twice.
         // I could use watchFile() but that polls every 5 seconds.  Not ideal.
-        if (fs.existsSync(this.userJsConfig)) {
+        if (fs.existsSync(this.getUserFolder())) {
             fs.watch(this.getUserFolder(), (event, filename) => {
                 if (event === "change" && filename === "config.js") {
                     // invalidate the Config currently stored in cache

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -110,14 +110,16 @@ class Config extends EventEmitter {
         // and continue to fire when file references are swapped out.
         // Unfortunately, this also means the 'change' event fires twice.
         // I could use watchFile() but that polls every 5 seconds.  Not ideal.
-        fs.watch(this.getUserFolder(), (event, filename) => {
-            if (event === "change" && filename === "config.js") {
-                // invalidate the Config currently stored in cache
-                delete global["require"].cache[global["require"].resolve(this.userJsConfig)] // tslint:disable-line no-string-literal
-                this.applyConfig()
-                this.notifyListeners()
-            }
-        })
+        if (fs.existsSync(this.userJsConfig)) {
+            fs.watch(this.getUserFolder(), (event, filename) => {
+                if (event === "change" && filename === "config.js") {
+                    // invalidate the Config currently stored in cache
+                    delete global["require"].cache[global["require"].resolve(this.userJsConfig)] // tslint:disable-line no-string-literal
+                    this.applyConfig()
+                    this.notifyListeners()
+                }
+            })
+        }
 
         Performance.mark("Config.load.end")
     }


### PR DESCRIPTION
The issue was with the `fs.watch` command when setting a listener for `config.js` changes.
```
"Uncaught Error: watch /home/keforbes/.oni ENOENT", source: fs.js (1318)
```
Check to see if the file exists before setting a listener on it.  This means the first launch of Oni won't automatically reload changes to `config.js`; they'll take effect on the next launch.