### PR TITLE
Move config options to Redux store (#353)

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -1,11 +1,13 @@
 import { EventEmitter } from "events"
+
 import * as fs from "fs"
+import * as _ from "lodash"
 import * as path from "path"
 
 import * as Performance from "./Performance"
 import * as Platform from "./Platform"
 
-interface IConfigValues {
+export interface IConfigValues {
     // Debug settings
     "debug.incrementalRenderRegions": boolean
     "debug.maxCellsToRender": number
@@ -177,6 +179,10 @@ class Config extends EventEmitter {
 
     public getValue<K extends keyof IConfigValues>(configValue: K) {
         return this.Config[configValue]
+    }
+
+    public getValues(): IConfigValues {
+        return _.cloneDeep(this.Config)
     }
 
     public getUserFolder(): string {

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -5,70 +5,117 @@ import * as path from "path"
 import * as Performance from "./Performance"
 import * as Platform from "./Platform"
 
+interface IConfigValues {
+    // Debug settings
+    "debug.incrementalRenderRegions": boolean
+    "debug.maxCellsToRender": number
+    "debug.fixedSize": {
+        rows: number,
+        columns: number,
+    } | null
+
+    // Production settings
+
+    // Bell sound effect to use
+    // See `:help bell` for instances where the bell sound would be used
+    "oni.audio.bellUrl": string
+
+    // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
+    // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
+    //
+    // Set this to 'false' to avoid loading the default config, and load settings from init.vim instead.
+    "oni.useDefaultConfig": boolean
+
+    // By default, user's init.vim is not loaded, to avoid conflicts.
+    // Set this to `true` to enable loading of init.vim.
+    "oni.loadInitVim": boolean
+
+    // Sets the `popupmenu_external` option in Neovim
+    // This will override the default UI to show a consistent popupmenu,
+    // whether using Oni's completion mechanisms or VIMs
+    //
+    // Use caution when changing the `menuopt` parameters if using
+    // a custom init.vim, as that may cause problematic behavior
+    "oni.useExternalPopupMenu": boolean
+
+    // If true, hide Menu bar by default
+    // (can still be activated by pressing 'Alt')
+    "oni.hideMenu": boolean
+
+    // glob pattern of files to exclude from fuzzy finder (Ctrl-P)
+    "oni.exclude": string[]
+
+    // Editor settings
+
+    "editor.backgroundOpacity": number
+    "editor.backgroundImageUrl": string
+    "editor.backgroundImageSize": string
+
+    "editor.quickInfo.enabled": boolean
+    // Delay (in ms) for showing QuickInfo, when the cursor is on a term
+    "editor.quickInfo.delay": number
+
+    "editor.completions.enabled": boolean
+    "editor.errors.slideOnFocus": boolean
+    "editor.formatting.formatOnSwitchToNormalMode": boolean // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
+
+    "editor.fontSize": string
+    "editor.fontFamily": string // Platform specific
+
+    // Command to list files for 'quick open'
+    // For example, to use 'ag': ag --nocolor -l .
+    //
+    // The command must emit a list of filenames
+    //
+    // IE, Windows:
+    // "editor.quickOpen.execCommand": "dir /s /b"
+    "editor.quickOpen.execCommand": string | null
+
+    "editor.fullScreenOnStart": boolean
+
+    "editor.cursorLine": boolean
+    "editor.cursorLineOpacity": number
+
+    "editor.cursorColumn": boolean
+    "editor.cursorColumnOpacity": number
+}
+
 class Config extends EventEmitter {
 
     public userJsConfig = path.join(this.getUserFolder(), "config.js")
 
-    private DefaultConfig: any = {
-        // Debug settings
+    private DefaultConfig: IConfigValues = {
         "debug.incrementalRenderRegions": false,
         "debug.maxCellsToRender": 12000,
+        "debug.fixedSize": null,
 
-        // Production settings
-
-        // Bell sound effect to use
-        // See `:help bell` for instances where the bell sound would be used
         "oni.audio.bellUrl": path.join(__dirname, "audio", "beep.wav"),
 
-        // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
-        // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
-        //
-        // Set this to 'false' to avoid loading the default config, and load settings from init.vim instead.
         "oni.useDefaultConfig": true,
 
-        // By default, user's init.vim is not loaded, to avoid conflicts.
-        // Set this to `true` to enable loading of init.vim.
         "oni.loadInitVim": false,
 
-        // Sets the `popupmenu_external` option in Neovim
-        // This will override the default UI to show a consistent popupmenu,
-        // whether using Oni's completion mechanisms or VIMs
-        //
-        // Use caution when changing the `menuopt` parameters if using
-        // a custom init.vim, as that may cause problematic behavior
         "oni.useExternalPopupMenu": true,
 
-        // If true, hide Menu bar by default
-        // (can still be activated by pressing 'Alt')
         "oni.hideMenu": false,
 
-        // glob pattern of files to exclude from fuzzy finder (Ctrl-P)
         "oni.exclude": ["**/node_modules/**"],
-
-        // Editor settings
 
         "editor.backgroundOpacity": 0.7,
         "editor.backgroundImageUrl": "images/background.png",
         "editor.backgroundImageSize": "initial",
 
         "editor.quickInfo.enabled": true,
-        // Delay (in ms) for showing QuickInfo, when the cursor is on a term
         "editor.quickInfo.delay": 500,
 
         "editor.completions.enabled": true,
         "editor.errors.slideOnFocus": true,
-        "editor.formatting.formatOnSwitchToNormalMode": false, // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
+        "editor.formatting.formatOnSwitchToNormalMode": false,
 
         "editor.fontSize": "14px",
-        // "editor.fontFamily" is platform-specific
+        "editor.fontFamily": "",
 
-        // Command to list files for 'quick open'
-        // For example, to use 'ag': ag --nocolor -l .
-        //
-        // The command must emit a list of filenames
-        //
-        // IE, Windows:
-        // "editor.quickOpen.execCommand": "dir /s /b"
+        "editor.quickOpen.execCommand": null,
 
         "editor.fullScreenOnStart" : false,
 
@@ -79,15 +126,15 @@ class Config extends EventEmitter {
         "editor.cursorColumnOpacity": 0.1,
     }
 
-    private MacConfig: any = {
+    private MacConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "Monaco",
     }
 
-    private WindowsConfig: any = {
+    private WindowsConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "Consolas",
     }
 
-    private LinuxConfig: any = {
+    private LinuxConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "DejaVu Sans Mono",
     }
 
@@ -95,7 +142,7 @@ class Config extends EventEmitter {
 
     private configChanged: EventEmitter = new EventEmitter()
 
-    private Config: any = {}
+    private Config: IConfigValues = null
 
     constructor() {
         super()
@@ -124,11 +171,11 @@ class Config extends EventEmitter {
         Performance.mark("Config.load.end")
     }
 
-    public hasValue(configValue: string): boolean {
-        return !!this.getValue<any>(configValue)
+    public hasValue(configValue: keyof IConfigValues): boolean {
+        return !!this.getValue(configValue)
     }
 
-    public getValue<T>(configValue: string): T {
+    public getValue<K extends keyof IConfigValues>(configValue: K) {
         return this.Config[configValue]
     }
 

--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -63,8 +63,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private _config = Config.instance()
 
-    private _fontFamily: string = this._config.getValue<string>("editor.fontFamily")
-    private _fontSize: string = this._config.getValue<string>("editor.fontSize")
+    private _fontFamily: string = this._config.getValue("editor.fontFamily")
+    private _fontSize: string = this._config.getValue("editor.fontSize")
     private _fontWidthInPixels: number
     private _fontHeightInPixels: number
 
@@ -304,7 +304,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private _resizeInternal(rows: number, columns: number): void {
 
         if (this._config.hasValue("debug.fixedSize")) {
-            const fixedSize = this._config.getValue<any>("debug.fixedSize")
+            const fixedSize = this._config.getValue("debug.fixedSize")
             rows = fixedSize.rows
             columns = fixedSize.columns
             console.warn("Overriding screen size based on debug.fixedSize")
@@ -391,7 +391,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 const completions = a[0][0]
                 this.emit("show-popup-menu", completions)
             } else if (command === "bell") {
-                const bellUrl = this._config.getValue<string>("oni.audio.bellUrl")
+                const bellUrl = this._config.getValue("oni.audio.bellUrl")
                 if (bellUrl) {
                     const audio = new Audio(bellUrl)
                     audio.play()
@@ -418,8 +418,8 @@ function startNeovim(runtimePaths: string[], args: any): Q.IPromise<any> {
 
     const joinedRuntimePaths = runtimePaths.join(",")
 
-    const shouldLoadInitVim = Config.instance().getValue<boolean>("oni.loadInitVim")
-    const useDefaultConfig = Config.instance().getValue<boolean>("oni.useDefaultConfig")
+    const shouldLoadInitVim = Config.instance().getValue("oni.loadInitVim")
+    const useDefaultConfig = Config.instance().getValue("oni.useDefaultConfig")
 
     const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -40,7 +40,7 @@ export class PluginManager extends EventEmitter {
 
         this._rootPluginPaths.push(corePluginsRoot)
 
-        if (this._config.getValue<boolean>("oni.useDefaultConfig")) {
+        if (this._config.getValue("oni.useDefaultConfig")) {
             this._rootPluginPaths.push(defaultPluginsRoot)
             this._rootPluginPaths.push(path.join(defaultPluginsRoot, "bundle"))
         }
@@ -163,7 +163,7 @@ export class PluginManager extends EventEmitter {
                         return
                     }
                     UI.Actions.showQuickInfo(pluginResponse.payload.info, pluginResponse.payload.documentation)
-                }, this._config.getValue<number>("editor.quickInfo.delay"))
+                }, this._config.getValue("editor.quickInfo.delay"))
             } else {
                 setTimeout(() => UI.Actions.hideQuickInfo())
             }
@@ -220,10 +220,10 @@ export class PluginManager extends EventEmitter {
             },
         }, Capabilities.createPluginFilter(this._lastEventContext.filetype, { subscriptions: ["vim-events"] }, false))
 
-        if (eventName === "CursorMoved" && this._config.getValue<boolean>("editor.quickInfo.enabled")) {
+        if (eventName === "CursorMoved" && this._config.getValue("editor.quickInfo.enabled")) {
             this._sendLanguageServiceRequest("quick-info", eventContext)
 
-        } else if (eventName === "CursorMovedI" && this._config.getValue<boolean>("editor.completions.enabled")) {
+        } else if (eventName === "CursorMovedI" && this._config.getValue("editor.completions.enabled")) {
             this._sendLanguageServiceRequest("completion-provider", eventContext)
 
             this._sendLanguageServiceRequest("signature-help", eventContext)

--- a/browser/src/Services/Formatter.ts
+++ b/browser/src/Services/Formatter.ts
@@ -22,7 +22,7 @@ export class Formatter {
         private _bufferUpdates: BufferUpdates,
     ) {
         this._neovimInstance.on("mode-change", (newMode: string) => {
-            if (this._config.getValue<boolean>("editor.formatting.formatOnSwitchToNormalMode")
+            if (this._config.getValue("editor.formatting.formatOnSwitchToNormalMode")
                 && newMode === "normal"
                 && this._lastMode === "insert") {
                 this.formatBuffer()

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -37,8 +37,8 @@ export class QuickOpen {
 
     public show(): void {
         const config = Config.instance()
-        const overrriddenCommand = config.getValue<string>("editor.quickOpen.execCommand")
-        const exclude = config.getValue<string[]>("oni.exclude")
+        const overrriddenCommand = config.getValue("editor.quickOpen.execCommand")
+        const exclude = config.getValue("oni.exclude")
 
         UI.Actions.showPopupMenu("quickOpen", [{
             icon: "refresh fa-spin fa-fw",

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -14,6 +14,8 @@ import { IScreen } from "./../Screen"
 
 import * as State from "./State"
 
+import * as Config from "./../Config"
+import * as Actions from "./Actions"
 import { events } from "./Events"
 
 export const showCompletions = (result: Oni.Plugin.CompletionResult) => (dispatch: Function, getState: Function) => {
@@ -173,6 +175,16 @@ export const setCursorColumnOpacity = (opacity: number) => ({
         opacity,
     },
 })
+
+export function setConfigurationValue<K extends keyof Config.IConfigValues>(k: K, v: Config.IConfigValues[K]): Actions.ISetConfigurationValue<K> {
+    return {
+        type: "SET_CONFIGURATION_VALUE",
+        payload: {
+            key: k,
+            value: v,
+        },
+    }
+}
 
 const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
     type: "SET_CURSOR_POSITION",

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -158,6 +158,9 @@ export interface ISetConfigurationValue<K extends keyof Config.IConfigValues> {
 }
 
 export type Action<K extends keyof Config.IConfigValues> =
+    SimpleAction | ActionWithGeneric<K>
+
+export type SimpleAction =
     ISetCursorPositionAction |
     IShowSignatureHelpAction |
     IHideSignatureHelpAction |
@@ -181,5 +184,7 @@ export type Action<K extends keyof Config.IConfigValues> =
     IShowCursorLineAction |
     IShowCursorColumnAction |
     ISetCursorColumnOpacityAction |
-    ISetCursorLineOpacityAction |
+    ISetCursorLineOpacityAction
+
+export type ActionWithGeneric<K extends keyof Config.IConfigValues> =
     ISetConfigurationValue<K>

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -7,6 +7,7 @@
  * http://redux.js.org/docs/basics/Actions.html
  */
 
+import * as Config from "./../Config"
 import { Rectangle } from "./Types"
 
 export interface ISetCursorPositionAction {
@@ -148,7 +149,16 @@ export interface ISetCursorColumnOpacityAction {
     }
 }
 
-export type Action = ISetCursorPositionAction |
+export interface ISetConfigurationValue<K extends keyof Config.IConfigValues> {
+    type: "SET_CONFIGURATION_VALUE"
+    payload: {
+        key: K,
+        value: Config.IConfigValues[K],
+    }
+}
+
+export type Action<K extends keyof Config.IConfigValues> =
+    ISetCursorPositionAction |
     IShowSignatureHelpAction |
     IHideSignatureHelpAction |
     IShowQuickInfoAction |
@@ -171,4 +181,5 @@ export type Action = ISetCursorPositionAction |
     IShowCursorLineAction |
     IShowCursorColumnAction |
     ISetCursorColumnOpacityAction |
-    ISetCursorLineOpacityAction
+    ISetCursorLineOpacityAction |
+    ISetConfigurationValue<K>

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -102,7 +102,7 @@ export function reducer<K extends keyof Config.IConfigValues> (s: State.IState, 
     }
 }
 
-export function popupMenuReducer<K extends keyof Config.IConfigValues> (s: State.IMenu | null, a: Actions.Action<K>) {
+export function popupMenuReducer (s: State.IMenu | null, a: Actions.SimpleAction) {
 
     // TODO: sync max display items (10) with value in Menu.render() (Menu.tsx)
     let size = s ? Math.min(10, s.filteredOptions.length) : 0
@@ -235,7 +235,7 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
     return highlightOptions
 }
 
-export function autoCompletionReducer<K extends keyof Config.IConfigValues> (s: State.IAutoCompletionInfo | null, a: Actions.Action<K>) {
+export function autoCompletionReducer (s: State.IAutoCompletionInfo | null, a: Actions.SimpleAction) {
     if (!s) {
         return s
     }
@@ -259,7 +259,7 @@ export function autoCompletionReducer<K extends keyof Config.IConfigValues> (s: 
     }
 }
 
-export function autoCompletionEntryReducer<K extends keyof Config.IConfigValues> (s: Oni.Plugin.CompletionInfo[], action: Actions.Action<K>) {
+export function autoCompletionEntryReducer (s: Oni.Plugin.CompletionInfo[], action: Actions.SimpleAction) {
     switch (action.type) {
         case "SET_AUTO_COMPLETION_DETAILS":
             return s.map((entry) => {

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -2,11 +2,12 @@ import * as State from "./State"
 
 import * as Fuse from "fuse.js"
 
+import * as Config from "./../Config"
 import * as Actions from "./Actions"
 
 import * as _ from "lodash"
 
-export const reducer = (s: State.IState, a: Actions.Action) => {
+export function reducer<K extends keyof Config.IConfigValues> (s: State.IState, a: Actions.Action<K>) {
 
     if (!s) {
         return s
@@ -86,6 +87,13 @@ export const reducer = (s: State.IState, a: Actions.Action) => {
             return Object.assign({}, s, {
                 cursorLineOpacity: a.payload.opacity,
             })
+        case "SET_CONFIGURATION_VALUE":
+            let obj: Partial<Config.IConfigValues> = {}
+            obj[a.payload.key] = a.payload.value
+            let newConfig = Object.assign({}, s.configuration, obj)
+            return Object.assign({}, s, {
+                configuration: newConfig,
+            })
         default:
             return Object.assign({}, s, {
                 autoCompletion: autoCompletionReducer(s.autoCompletion, a), // FIXME: null
@@ -94,7 +102,7 @@ export const reducer = (s: State.IState, a: Actions.Action) => {
     }
 }
 
-export const popupMenuReducer = (s: State.IMenu | null, a: Actions.Action) => {
+export function popupMenuReducer<K extends keyof Config.IConfigValues> (s: State.IMenu | null, a: Actions.Action<K>) {
 
     // TODO: sync max display items (10) with value in Menu.render() (Menu.tsx)
     let size = s ? Math.min(10, s.filteredOptions.length) : 0
@@ -227,7 +235,7 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
     return highlightOptions
 }
 
-export const autoCompletionReducer = (s: State.IAutoCompletionInfo | null, a: Actions.Action) => {
+export function autoCompletionReducer<K extends keyof Config.IConfigValues> (s: State.IAutoCompletionInfo | null, a: Actions.Action<K>) {
     if (!s) {
         return s
     }
@@ -251,7 +259,7 @@ export const autoCompletionReducer = (s: State.IAutoCompletionInfo | null, a: Ac
     }
 }
 
-export const autoCompletionEntryReducer = (s: Oni.Plugin.CompletionInfo[], action: Actions.Action) => {
+export function autoCompletionEntryReducer<K extends keyof Config.IConfigValues> (s: Oni.Plugin.CompletionInfo[], action: Actions.Action<K>) {
     switch (action.type) {
         case "SET_AUTO_COMPLETION_DETAILS":
             return s.map((entry) => {

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -26,6 +26,10 @@ export interface IState {
     activeWindowDimensions: Rectangle
 }
 
+export const readConf <K extends keyof Config.IConfigValues>(conf: Config.IConfigValues, k: K): Config.IConfigValues[K] {
+    return conf[k]
+}
+
 export interface IMenu {
     id: string,
     filter: string,

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -26,7 +26,7 @@ export interface IState {
     activeWindowDimensions: Rectangle
 }
 
-export const readConf <K extends keyof Config.IConfigValues>(conf: Config.IConfigValues, k: K): Config.IConfigValues[K] {
+export function readConf <K extends keyof Config.IConfigValues>(conf: Config.IConfigValues, k: K): Config.IConfigValues[K] {
     return conf[k]
 }
 

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -1,4 +1,5 @@
 
+import * as Config from  "./../Config"
 import { Rectangle } from "./Types"
 
 export interface IState {
@@ -19,6 +20,7 @@ export interface IState {
     cursorLineOpacity: number
     cursorColumnVisible: boolean
     cursorColumnOpacity: number
+    configuration: Config.IConfigValues
 
     // Dimensions of active window, in pixels
     activeWindowDimensions: Rectangle
@@ -52,7 +54,7 @@ export interface IAutoCompletionInfo {
     selectedIndex: number
 }
 
-export const createDefaultState = () => (<IState>{
+export const createDefaultState = (): IState => ({
     cursorPixelX: 10,
     cursorPixelY: 10,
     cursorPixelWidth: 10,
@@ -76,4 +78,5 @@ export const createDefaultState = () => (<IState>{
     cursorColumnVisible: false,
     cursorColumnOpacity: 0,
     backgroundColor: "#000000",
+    configuration: Config.instance().getValues(),
 })

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -1,24 +1,24 @@
 import * as React from "react"
 
 import { connect } from "react-redux"
-import * as Config from "./../../Config"
 import * as State from "./../State"
 
 export interface IBackgroundProps {
     backgroundColor: string
+    backgroundImageUrl: string
+    backgroundImageSize: string
+    backgroundOpacity: number
 }
 
 export class BackgroundRenderer extends React.Component<IBackgroundProps, void> {
-    private config = Config.instance()
-
     public render(): JSX.Element {
         const imageStyle = {
-            backgroundImage: "url(" + this.config.getValue("editor.backgroundImageUrl") + ")",
-            backgroundSize: this.config.getValue("editor.backgroundImageSize") || "cover",
+            backgroundImage: "url(" + this.props.backgroundImageUrl + ")",
+            backgroundSize: this.props.backgroundImageSize || "cover",
         }
         const coverStyle = {
             backgroundColor: this.props.backgroundColor,
-            opacity: this.config.getValue("editor.backgroundOpacity"),
+            opacity: this.props.backgroundOpacity,
         }
 
         return <div>
@@ -28,9 +28,13 @@ export class BackgroundRenderer extends React.Component<IBackgroundProps, void> 
     }
 }
 
-const mapStateToProps = (state: State.IState) => {
+const mapStateToProps = (state: State.IState): IBackgroundProps => {
+    let conf = state.configuration
     return {
         backgroundColor: state.backgroundColor,
+        backgroundImageUrl: State.readConf(conf, "editor.backgroundImageUrl"),
+        backgroundImageSize: State.readConf(conf, "editor.backgroundImageSize"),
+        backgroundOpacity: State.readConf(conf, "editor.backgroundOpacity"),
     }
 }
 

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -13,12 +13,12 @@ export class BackgroundRenderer extends React.Component<IBackgroundProps, void> 
 
     public render(): JSX.Element {
         const imageStyle = {
-            backgroundImage: "url(" + this.config.getValue<string>("editor.backgroundImageUrl") + ")",
-            backgroundSize: this.config.getValue<string>("editor.backgroundImageSize") || "cover",
+            backgroundImage: "url(" + this.config.getValue("editor.backgroundImageUrl") + ")",
+            backgroundSize: this.config.getValue("editor.backgroundImageSize") || "cover",
         }
         const coverStyle = {
             backgroundColor: this.props.backgroundColor,
-            opacity: this.config.getValue<number>("editor.backgroundOpacity"),
+            opacity: this.config.getValue("editor.backgroundOpacity"),
         }
 
         return <div>

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -22,8 +22,8 @@ class CursorRenderer extends React.Component<ICursorProps, void> {
 
     public render(): JSX.Element {
 
-        const fontFamily = this.config.getValue<string>("editor.fontFamily")
-        const fontSize = this.config.getValue<string>("editor.fontSize")
+        const fontFamily = this.config.getValue("editor.fontFamily")
+        const fontSize = this.config.getValue("editor.fontSize")
 
         const isNormalMode = this.props.mode === "normal"
         const width = isNormalMode ? this.props.width : this.props.width / 4

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { connect } from "react-redux"
 
-import * as Config from "./../../Config"
 import * as State from "./../State"
 
 export interface ICursorProps {
@@ -12,18 +11,18 @@ export interface ICursorProps {
     mode: string
     color: string
     character: string
+    fontFamily: string
+    fontSize: string
 }
 
 require("./Cursor.less") // tslint:disable-line no-var-requires
 
 class CursorRenderer extends React.Component<ICursorProps, void> {
 
-    private config = Config.instance()
-
     public render(): JSX.Element {
 
-        const fontFamily = this.config.getValue("editor.fontFamily")
-        const fontSize = this.config.getValue("editor.fontSize")
+        const fontFamily = this.props.fontFamily
+        const fontSize = this.props.fontSize
 
         const isNormalMode = this.props.mode === "normal"
         const width = isNormalMode ? this.props.width : this.props.width / 4
@@ -45,7 +44,7 @@ class CursorRenderer extends React.Component<ICursorProps, void> {
     }
 }
 
-const mapStateToProps = (state: State.IState) => {
+const mapStateToProps = (state: State.IState): ICursorProps => {
     return {
         x: state.cursorPixelX,
         y: state.cursorPixelY,
@@ -54,6 +53,8 @@ const mapStateToProps = (state: State.IState) => {
         mode: state.mode,
         color: state.foregroundColor,
         character: state.cursorCharacter,
+        fontFamily: State.readConf(state.configuration, "editor.fontFamily"),
+        fontSize: State.readConf(state.configuration, "editor.fontSize"),
     }
 }
 

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -84,7 +84,7 @@ export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
 
         let className = this.props.isActive ? "error-marker active" : "error-marker"
 
-        const errorDescription = this.config.getValue<boolean>("editor.errors.slideOnFocus") ? (<div className="error">
+        const errorDescription = this.config.getValue("editor.errors.slideOnFocus") ? (<div className="error">
             <div className="text">
                 {this.props.text}
             </div>

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -32,6 +32,8 @@ import { SyntaxHighlighter } from "./Services/SyntaxHighlighter"
 import { Tasks } from "./Services/Tasks"
 import { WindowTitle } from "./Services/WindowTitle"
 
+import * as _ from "lodash"
+
 import * as UI from "./UI/index"
 import { ErrorOverlay } from "./UI/Overlay/ErrorOverlay"
 import { LiveEvaluationOverlay } from "./UI/Overlay/LiveEvaluationOverlay"
@@ -243,10 +245,20 @@ const start = (args: string[]) => {
     }
 
     const config = Config.instance()
+    let prevConfigValues = config.getValues()
 
     const configChange = () => {
         cursorLine = config.getValue("editor.cursorLine")
         cursorColumn = config.getValue("editor.cursorColumn")
+
+        let newConfigValues = config.getValues()
+        for (let prop in newConfigValues) {
+            if (!_.isEqual(newConfigValues[prop], prevConfigValues[prop])) {
+                UI.Actions.setConfigValue(prop, newConfigValues[prop])
+            }
+        }
+        prevConfigValues = newConfigValues
+
         UI.Actions.setCursorLineOpacity(config.getValue("editor.cursorLineOpacity"))
         UI.Actions.setCursorColumnOpacity(config.getValue("editor.cursorColumnOpacity"))
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -245,10 +245,10 @@ const start = (args: string[]) => {
     const config = Config.instance()
 
     const configChange = () => {
-        cursorLine = config.getValue<boolean>("editor.cursorLine")
-        cursorColumn = config.getValue<boolean>("editor.cursorColumn")
-        UI.Actions.setCursorLineOpacity(config.getValue<number>("editor.cursorLineOpacity"))
-        UI.Actions.setCursorColumnOpacity(config.getValue<number>("editor.cursorColumnOpacity"))
+        cursorLine = config.getValue("editor.cursorLine")
+        cursorColumn = config.getValue("editor.cursorColumn")
+        UI.Actions.setCursorLineOpacity(config.getValue("editor.cursorLineOpacity"))
+        UI.Actions.setCursorColumnOpacity(config.getValue("editor.cursorColumnOpacity"))
 
         if (cursorLine) {
             UI.Actions.showCursorLine()
@@ -259,19 +259,19 @@ const start = (args: string[]) => {
         }
 
         const window = remote.getCurrentWindow()
-        const hideMenu: boolean = config.getValue<boolean>("oni.hideMenu")
+        const hideMenu: boolean = config.getValue("oni.hideMenu")
         window.setAutoHideMenuBar(hideMenu)
         window.setMenuBarVisibility(!hideMenu)
 
-        const loadInit: boolean = config.getValue<boolean>("oni.loadInitVim")
+        const loadInit: boolean = config.getValue("oni.loadInitVim")
         if (loadInit !== loadInitVim) {
             ipcRenderer.send("rebuild-menu", loadInit)
             // don't rebuild menu unless oni.loadInitVim actually changed
             loadInitVim = loadInit
         }
 
-        window.setFullScreen(config.getValue<boolean>("editor.fullScreenOnStart"))
-        instance.setFont(config.getValue<string>("editor.fontFamily"), config.getValue<string>("editor.fontSize"))
+        window.setFullScreen(config.getValue("editor.fullScreenOnStart"))
+        instance.setFont(config.getValue("editor.fontFamily"), config.getValue("editor.fontSize"))
         updateFunction()
     }
     configChange() // initialize values


### PR DESCRIPTION
This bothered me when I was making the Background component, so I thought I'd take a stab at this.

Some remarks: I might have went overboard with the type safety. I write a lot of PureScript so I like type safety a lot, but adding type safety to the configuration object was a bit annoying, so I can totally understand if you want me to dial it down. Secondly, I had to make this State.readConf function to make reading the IConfigValues interface safe, since just indexing into it (eg. state.configuration["editor.backgroundImageUrl"]) is unsafe since we us "suppressImplicitAnyIndexErrors": true.

Just let me know how far you want the type safety to go, I'll adjust to what you feel is right.

Secondly I only updated the components to read from the redux store. Services that want to read from the config keep their own reference to the instance, which is OK for now I think. The Error.tsx component isn't hooked up to redux, so I left that for now.

Again, this is just my interpretation so I'll change anything/everything you want me to. 

I tried to keep the separate commits small and consistent to aid with code review.