### PR TITLE
Fix config live reload, pop-up config.js parse errors

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -203,8 +203,7 @@ class Config extends EventEmitter {
             try {
                 userRuntimeConfig = global["require"](this.userJsConfig) // tslint:disable-line no-string-literal
             } catch (e) {
-                // TODO: display this error to the user somehow
-                console.log("Failed to parse " + this.userJsConfig + ": " + (<Error>e).message) // tslint:disable-line no-console
+                alert("Failed to parse " + this.userJsConfig + ":\n" + (<Error>e).message)
             }
         }
         this.Config = { ...this.DefaultConfig, ...this.DefaultPlatformConfig, ...userRuntimeConfig }

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -176,7 +176,7 @@ export const setCursorColumnOpacity = (opacity: number) => ({
     },
 })
 
-export function setConfigurationValue<K extends keyof Config.IConfigValues>(k: K, v: Config.IConfigValues[K]): Actions.ISetConfigurationValue<K> {
+export function setConfigValue<K extends keyof Config.IConfigValues>(k: K, v: Config.IConfigValues[K]): Actions.ISetConfigurationValue<K> {
     return {
         type: "SET_CONFIGURATION_VALUE",
         payload: {


### PR DESCRIPTION
I was already logging to the console when `config.js` has parsing errors but I wanted to put the error somewhere the user would actually see it.  I changed the `console.log` to an `alert` so it now pops up in the user's face.

While testing this out, I was getting an error in `index.tsx` that `UI.Actions.setConfigValue` was not a method.  It turns out the method was actually named `setConfigurationValue`.  This was introduced in #356.  I changed the method name in `ActionCreators.ts` to match the expected name used in `index.tsx` and changes to `config.js` automatically take effect once again.