### PR TITLE
Improve type safety of ActionCreators

### DIFF
--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -34,7 +34,7 @@ const enhancer = composeEnhancers(
 
 const store = createStore(reducer, defaultState, enhancer)
 
-export const Actions = bindActionCreators(ActionCreators as any, store.dispatch)
+export const Actions: typeof ActionCreators = bindActionCreators(ActionCreators as any, store.dispatch)
 
 // TODO: Is there a helper utility like `bindActionCreators`, but for selectors?
 export const Selectors = {

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -105,7 +105,7 @@ const start = (args: string[]) => {
     overlayManager.addOverlay("live-eval", liveEvaluationOverlay)
     overlayManager.addOverlay("scrollbar", scrollbarOverlay)
 
-    overlayManager.on("current-window-size-changed", (dimensionsInPixels: Rectangle) => UI.Actions.setActiveWindowDimensionsChanged(dimensionsInPixels))
+    overlayManager.on("current-window-size-changed", (dimensionsInPixels: Rectangle) => UI.Actions.setActiveWindowDimensions(dimensionsInPixels))
 
     pluginManager.on("signature-help-response", (err: string, signatureHelp: any) => { // FIXME: setup Oni import
         if (err) {
@@ -252,7 +252,8 @@ const start = (args: string[]) => {
         cursorColumn = config.getValue("editor.cursorColumn")
 
         let newConfigValues = config.getValues()
-        for (let prop in newConfigValues) {
+        let prop: keyof Config.IConfigValues
+        for (prop in newConfigValues) {
             if (!_.isEqual(newConfigValues[prop], prevConfigValues[prop])) {
                 UI.Actions.setConfigValue(prop, newConfigValues[prop])
             }


### PR DESCRIPTION
As evidenced by (#358), the cast to any UI/index.tsx of the ActionCreators takes away a lot of the type safety that is present in Actions.tsx and ActionCreators.tsx. This PR makes sure we keep that type safety.

It even uncovered a bug immediately!