### PR TITLE
Refactor InstallHelp into redux + RootComponent (#313)

### DIFF
--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -186,6 +186,10 @@ export function setConfigValue<K extends keyof Config.IConfigValues>(k: K, v: Co
     }
 }
 
+export const showNeovimInstallHelp = (): Actions.IShowNeovimInstallHelp => ({
+    type: "SHOW_NEOVIM_INSTALL_HELP",
+})
+
 const _setCursorPosition = (cursorPixelX: any, cursorPixelY: any, fontPixelWidth: any, fontPixelHeight: any, cursorCharacter: string, cursorPixelWidth: number) => ({
     type: "SET_CURSOR_POSITION",
     payload: {

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -186,7 +186,7 @@ export function setConfigValue<K extends keyof Config.IConfigValues>(k: K, v: Co
     }
 }
 
-export const showNeovimInstallHelp = (): Actions.IShowNeovimInstallHelp => ({
+export const showNeovimInstallHelp = (): Actions.IShowNeovimInstallHelpAction => ({
     type: "SHOW_NEOVIM_INSTALL_HELP",
 })
 

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -157,7 +157,7 @@ export interface ISetConfigurationValue<K extends keyof Config.IConfigValues> {
     }
 }
 
-export interface IShowNeovimInstallHelp {
+export interface IShowNeovimInstallHelpAction {
     type: "SHOW_NEOVIM_INSTALL_HELP"
 }
 
@@ -189,7 +189,7 @@ export type SimpleAction =
     IShowCursorColumnAction |
     ISetCursorColumnOpacityAction |
     ISetCursorLineOpacityAction |
-    IShowNeovimInstallHelp
+    IShowNeovimInstallHelpAction
 
 export type ActionWithGeneric<K extends keyof Config.IConfigValues> =
     ISetConfigurationValue<K>

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -157,6 +157,10 @@ export interface ISetConfigurationValue<K extends keyof Config.IConfigValues> {
     }
 }
 
+export interface IShowNeovimInstallHelp {
+    type: "SHOW_NEOVIM_INSTALL_HELP"
+}
+
 export type Action<K extends keyof Config.IConfigValues> =
     SimpleAction | ActionWithGeneric<K>
 
@@ -184,7 +188,8 @@ export type SimpleAction =
     IShowCursorLineAction |
     IShowCursorColumnAction |
     ISetCursorColumnOpacityAction |
-    ISetCursorLineOpacityAction
+    ISetCursorLineOpacityAction |
+    IShowNeovimInstallHelp
 
 export type ActionWithGeneric<K extends keyof Config.IConfigValues> =
     ISetConfigurationValue<K>

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -94,6 +94,10 @@ export function reducer<K extends keyof Config.IConfigValues> (s: State.IState, 
             return Object.assign({}, s, {
                 configuration: newConfig,
             })
+        case "SHOW_NEOVIM_INSTALL_HELP":
+            return Object.assign({}, s, {
+                showNeovimInstallHelp: true,
+            })
         default:
             return Object.assign({}, s, {
                 autoCompletion: autoCompletionReducer(s.autoCompletion, a), // FIXME: null

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -1,15 +1,26 @@
 import * as React from "react"
 
+import { connect } from "react-redux"
 import { AutoCompletionContainer } from "./components/AutoCompletion"
 import { Cursor } from "./components/Cursor"
 import { CursorLine } from "./components/CursorLine"
+import { InstallHelp } from "./components/InstallHelp"
 import { MenuContainer } from "./components/Menu"
 import { QuickInfoContainer, SignatureHelpContainer } from "./components/QuickInfo"
+import * as State from "./State"
 
-export class RootComponent extends React.Component<void, void> {
+interface IRootComponentProps {
+    showNeovimInstallHelp: boolean
+}
+
+export class RootComponentRenderer extends React.Component<IRootComponentProps, void> {
     public render() {
 
-        return <div className="ui-overlay">
+        return this.props.showNeovimInstallHelp ?
+        <div className="ui-overlay">
+          <InstallHelp />
+        </div> :
+        <div className="ui-overlay">
             <Cursor />
             <CursorLine lineType={"line"} />
             <CursorLine lineType={"column"} />
@@ -21,3 +32,11 @@ export class RootComponent extends React.Component<void, void> {
         </div>
     }
 }
+
+const mapStateToProps = (state: State.IState): IRootComponentProps => {
+    return {
+        showNeovimInstallHelp: state.showNeovimInstallHelp,
+    }
+}
+
+export const RootComponent = connect(mapStateToProps)(RootComponentRenderer)

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -21,6 +21,7 @@ export interface IState {
     cursorColumnVisible: boolean
     cursorColumnOpacity: number
     configuration: Config.IConfigValues
+    showNeovimInstallHelp: boolean
 
     // Dimensions of active window, in pixels
     activeWindowDimensions: Rectangle
@@ -82,5 +83,6 @@ export const createDefaultState = (): IState => ({
     cursorColumnVisible: false,
     cursorColumnOpacity: 0,
     backgroundColor: "#000000",
+    showNeovimInstallHelp: false,
     configuration: Config.instance().getValues(),
 })

--- a/browser/src/UI/index.tsx
+++ b/browser/src/UI/index.tsx
@@ -13,19 +13,12 @@ import * as State from "./State"
 import * as ActionCreators from "./ActionCreators"
 import { reducer } from "./Reducer"
 
-import { InstallHelp } from "./components/InstallHelp"
-
 import * as Events from "./Events"
 import * as UnboundSelectors from "./Selectors"
 
 export const events = Events.events
 
 let defaultState = State.createDefaultState()
-
-export function showNeovimInstallHelp(): void {
-    const element = document.getElementById("overlay-ui")
-    ReactDOM.render(<InstallHelp />, element)
-}
 
 const composeEnhancers = window["__REDUX_DEVTOOLS_EXTENSION__COMPOSE__"] || compose // tslint:disable-line no-string-literal
 const enhancer = composeEnhancers(

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -171,7 +171,7 @@ const start = (args: string[]) => {
     })
 
     instance.on("error", (_err: string) => {
-        UI.showNeovimInstallHelp()
+        UI.Actions.showNeovimInstallHelp()
     })
 
     instance.on("buffer-update", (context: any, lines: string[]) => {


### PR DESCRIPTION
This should take care of #313. I added the if-statement to the RootComponent. It was the only way to keep the current behaviour, namely showing none of the other UI elements when we're showing the install help. I'm ok with this placement, but if you want it somewhere else, ie. more localized in the InstallHelp component alone, let me know.