### PR TITLE
Fix #374: Add 'editor.fontLigatures' boolean setting, and pick up when config c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A few interesting configuration options to set:
 - `oni.hideMenu` - (default: `false`) If true, hide menu bar.  When hidden, menu bar can still be displayed with `Alt`.
 - `editor.fontSize` - Font size
 - `editor.fontFamily` - Font family
+- `editor.fontLigatures` - (default: `true`). If true, ligatures are enabled.
 - `editor.backgroundImageUrl` - specific a custom background image
 - `editor.backgroundImageSize` - specific a custom background size (cover, contain)
 

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -61,6 +61,8 @@ export interface IConfigValues {
     "editor.errors.slideOnFocus": boolean
     "editor.formatting.formatOnSwitchToNormalMode": boolean // TODO: Make this setting reliable. If formatting is slow, it will hose edits... not fun
 
+    // If true (default), ligatures are enabled
+    "editor.fontLigatures": boolean
     "editor.fontSize": string
     "editor.fontFamily": string // Platform specific
 
@@ -114,6 +116,7 @@ class Config extends EventEmitter {
         "editor.errors.slideOnFocus": true,
         "editor.formatting.formatOnSwitchToNormalMode": false,
 
+        "editor.fontLigatures": true,
         "editor.fontSize": "14px",
         "editor.fontFamily": "",
 

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -307,6 +307,8 @@ const start = (args: string[]) => {
             UI.Actions.showCursorColumn()
         }
 
+        document.body.style.fontVariant = config.getValue("editor.fontLigatures") ? "normal" : "none"
+
         const window = remote.getCurrentWindow()
         const hideMenu: boolean = config.getValue("oni.hideMenu")
         window.setAutoHideMenuBar(hideMenu)


### PR DESCRIPTION
Adds `editor.fontLigatures` setting.

If _true_ (default), ligatures are enabled.
If _false_, ligatures are disabled.