### PR TITLE
[Cleanup] change lists of else-if statements to switch statements

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -340,26 +340,24 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private _handleNotification(_method: any, args: any): void {
         args.forEach((a: any[]) => {
-            const command = a[0]
-            a.shift()
-
-            if (command === "cursor_goto") {
+            const command = a.shift()
+            switch (command) {
+            case "cursor_goto":
                 this.emit("action", Actions.createCursorGotoAction(a[0][0], a[0][1]))
-            } else if (command === "put") {
-
+                break
+            case "put":
                 const charactersToPut = a.map((v) => v[0])
                 this.emit("action", Actions.put(charactersToPut))
-            } else if (command === "set_scroll_region") {
+                break
+            case "set_scroll_region":
                 const param = a[0]
                 this.emit("action", Actions.setScrollRegion(param[0], param[1], param[2], param[3]))
-            } else if (command === "scroll") {
+                break
+            case "scroll":
                 this.emit("action", Actions.scroll(a[0][0]))
-            } else if (command === "highlight_set") {
-
-                const count = a.length
-
-                const highlightInfo = a[count - 1][0]
-
+                break
+            case "highlight_set":
+                const highlightInfo = a[a.length - 1][0]
                 this.emit("action", Actions.setHighlight(
                     !!highlightInfo.bold,
                     !!highlightInfo.italic,
@@ -369,34 +367,48 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     highlightInfo.foreground,
                     highlightInfo.background,
                 ))
-            } else if (command === "resize") {
+                break
+            case "resize":
                 this.emit("action", Actions.resize(a[0][0], a[0][1]))
-            } else if (command === "set_title") {
+                break
+            case "set_title":
                 this.emit("set-title", a[0][0])
-            } else if (command === "eol_clear") {
+                break
+            case "set_icon":
+                // window title when minimized, no-op
+                break
+            case "eol_clear":
                 this.emit("action", Actions.clearToEndOfLine())
-            } else if (command === "clear") {
+                break
+            case "clear":
                 this.emit("action", Actions.clear())
-            } else if (command === "mouse_on") {
+                break
+            case "mouse_on":
                 // TODO
-            } else if (command === "update_bg") {
+                break
+            case "update_bg":
                 this.emit("action", Actions.updateBackground(a[0][0]))
-            } else if (command === "update_fg") {
+                break
+            case "update_fg":
                 this.emit("action", Actions.updateForeground(a[0][0]))
-            } else if (command === "mode_change") {
+                break
+            case "mode_change":
                 const newMode = a[0][0]
                 this.emit("action", Actions.changeMode(newMode))
                 this.emit("mode-change", newMode)
-            } else if (command === "popupmenu_show") {
+                break
+            case "popupmenu_show":
                 const completions = a[0][0]
                 this.emit("show-popup-menu", completions)
-            } else if (command === "bell") {
+                break
+            case "bell":
                 const bellUrl = this._config.getValue("oni.audio.bellUrl")
                 if (bellUrl) {
                     const audio = new Audio(bellUrl)
                     audio.play()
                 }
-            } else {
+                break
+            default:
                 this.emit("logWarning", "Unhandled command: " + command)
             }
         })

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -151,7 +151,8 @@ export class PluginManager extends EventEmitter {
         // TODO: Refactor these handlers to separate classes
         // - pluginManager.registerResponseHandler("show-quick-info", new QuickInfoHandler())
 
-        if (pluginResponse.type === "show-quick-info") {
+        switch (pluginResponse.type) {
+        case "show-quick-info":
             if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
                 return
             }
@@ -167,7 +168,8 @@ export class PluginManager extends EventEmitter {
             } else {
                 setTimeout(() => UI.Actions.hideQuickInfo())
             }
-        } else if (pluginResponse.type === "goto-definition") {
+            break
+        case "goto-definition":
             if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
                 return
             }
@@ -177,7 +179,8 @@ export class PluginManager extends EventEmitter {
             this._neovimInstance.command("e! " + filePath)
             this._neovimInstance.command(`cal cursor(${line}, ${column})`)
             this._neovimInstance.command("norm zz")
-        } else if (pluginResponse.type === "completion-provider") {
+            break
+        case "completion-provider":
             if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
                 return
             }
@@ -187,25 +190,37 @@ export class PluginManager extends EventEmitter {
             }
 
             setTimeout(() => UI.Actions.showCompletions(pluginResponse.payload))
-        } else if (pluginResponse.type === "completion-provider-item-selected") {
+            break
+        case "completion-provider-item-selected":
             setTimeout(() => UI.Actions.setDetailedCompletionEntry(pluginResponse.payload.details))
-        } else if (pluginResponse.type === "set-errors") {
+            break
+        case "set-errors":
             this.emit("set-errors", pluginResponse.payload.key, pluginResponse.payload.fileName, pluginResponse.payload.errors, pluginResponse.payload.color)
-        } else if (pluginResponse.type === "find-all-references") {
+            break
+        case "find-all-references":
             this.emit("find-all-references", pluginResponse.payload.references)
-        } else if (pluginResponse.type === "format") {
+            break
+        case "format":
             this.emit("format", pluginResponse.payload)
-        } else if (pluginResponse.type === "execute-shell-command") {
+            break
+        case "execute-shell-command":
             // TODO: Check plugin permission
             this.emit("execute-shell-command", pluginResponse.payload)
-        } else if (pluginResponse.type === "evaluate-block-result") {
+            break
+        case "evaluate-block-result":
             this.emit("evaluate-block-result", pluginResponse.payload)
-        } else if (pluginResponse.type === "set-syntax-highlights") {
+            break
+        case "set-syntax-highlights":
             this.emit("set-syntax-highlights", pluginResponse.payload)
-        } else if (pluginResponse.type === "clear-syntax-highlights") {
+            break
+        case "clear-syntax-highlights":
             this.emit("clear-syntax-highlights", pluginResponse.payload)
-        } else if (pluginResponse.type === "signature-help-response") {
+            break
+        case "signature-help-response":
             this.emit("signature-help-response", pluginResponse.error, pluginResponse.payload)
+            break
+        default:
+            this.emit("logWarning", "Unexpected plugin type: " + pluginResponse.type)
         }
     }
 


### PR DESCRIPTION
I had intended to only add a clause for the `set_icon` event so we wouldn't get the `Unhandled command: set_icon` warning anymore.  The `set_title` event tells us the window title to set, the `set_icon` event just tells us the title to use when the window is minimized.  Even the Neovim docs say:
```
In windowing systems not distinguishing between the two, "set_icon" can be ignored.
```

After making that change though, I felt compelled to change the list of `else if` statements into a `switch` statement.  I then looked for more occurrences of these lists of `else if` statements and only found one other offender.

So yeah, functionally, this Pull Request does nothing.  It just cleans up some annoyances in the code I've been wanting to address.