### PR TITLE
Fix #375: Error when closing existing language client connection

### DIFF
--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -160,7 +160,7 @@ export class LanguageClient {
 
         this._connection = null
         this._currentOpenDocumentPath = null
-        return null
+        return Promise.resolve(null)
     }
 
     private _enqueuePromise<T>(functionThatReturnsPromiseOrThenable: () => Promise<T> | Thenable<T>, requireConnection: boolean = true): Promise<T> {


### PR DESCRIPTION
Fix #375. Was returning `null` instead of a promise. Once this is fixed, you can switch between .csproj projects within a single session.