### PR TITLE
Fix #392, 'setMenu of null' with multiple instances

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,7 +70,9 @@ function createWindow(commandLineArguments, workingDirectory) {
     })
 
     ipcMain.on('rebuild-menu', function(_evt, loadInit) {
-        updateMenu(mainWindow, loadInit)
+        if (mainWindow) {
+            updateMenu(mainWindow, loadInit)
+        }
     })
 
     // and load the index.html of the app.

--- a/main.js
+++ b/main.js
@@ -70,6 +70,8 @@ function createWindow(commandLineArguments, workingDirectory) {
     })
 
     ipcMain.on('rebuild-menu', function(_evt, loadInit) {
+        // ipcMain is a singleton so if there are multiple Oni instances
+        // we may receive an event from a different instance
         if (mainWindow) {
             updateMenu(mainWindow, loadInit)
         }


### PR DESCRIPTION
This is more of a workaround than a true fix but it works fine.  Basically, we're setting the `rebuild-menu` event listener on `ipcMain` but there is only a single instance of `ipcMain` across all Oni windows.  When one of the instances receives a `rebuild-menu` event from one of the other instances it would try calling `mainWindow.setMenu()` and get this error.

My fix is to just ignore the event if `mainWindow` is null.  So it avoids the error but I feel like in the future we should find a way to isolate the Oni instances a little better.