### PR TITLE
Fix #345: Add 'Run Oni.exe' option to windows installer

### DIFF
--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -24,7 +24,7 @@ const prodName = packageMeta.build.productName
 
 const valuesToReplace = {
     "AppName": prodName,
-    "AppExecutableName": `${name}.exe`,
+    "AppExecutableName": `${prodName}.exe`,
     "AppSetupExecutableName": `${prodName}-${version}-ia32-win`,
     "Version": version,
     "SourcePath": path.join(__dirname, "..", "dist", "win-ia32-unpacked", "*"),

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -23,8 +23,7 @@ const prodName = packageMeta.build.productName
 // Replace template variables
 
 const valuesToReplace = {
-    "AppName": name,
-    "ProdName": prodName,
+    "AppName": prodName,
     "AppExecutableName": `${name}.exe`,
     "AppSetupExecutableName": `${prodName}-${version}-ia32-win`,
     "Version": version,

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -25,3 +25,6 @@ Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Icons]
 Name: "{group}\{{AppName}}"; Filename: "{app}\{{AppExecutableName}}"
+
+[Run]
+Filename: "{app}\{{AppExecutableName}}"; Flags: postinstall skipifsilent

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -10,8 +10,8 @@
 [Setup]
 AppName={{AppName}}
 AppVersion={{Version}}
-DefaultDirName={pf}\{{ProdName}}
-DefaultGroupName={{ProdName}}
+DefaultDirName={pf}\{{AppName}}
+DefaultGroupName={{AppName}}
 UninstallDisplayIcon={app}\{{AppExecutableName}}
 Compression=zip
 SolidCompression=yes


### PR DESCRIPTION
Fix #345 

This adds an option to 'Run Oni.exe' at the conclusion of the windows installer. In addition, I built on @keforbes fixes to make the casing consistently uppercase, since that is the expected behavior on Windows (so now it shows up in the start menu as "Oni").