### PR TITLE
Fix # 391: Errors overlay the completion logic.

### DIFF
--- a/browser/src/UI/Overlay/ErrorOverlay.ts
+++ b/browser/src/UI/Overlay/ErrorOverlay.ts
@@ -13,6 +13,13 @@ export class ErrorOverlay implements IOverlay {
     private _currentFileName: string
     private _lastWindowContext: WindowContext
 
+    /**
+     * Whether or not error details should be shown.
+     * In insert mode, we shouldn't show details, because that will overlay completion elements
+     * Some LSP providers push error data while changes are being made, whereas others wait until save.
+     */
+    private _showDetails: boolean;
+
     public onVimEvent(_eventName: string, eventContext: Oni.EventContext): void {
 
         if (_eventName === "BufEnter") {
@@ -21,6 +28,16 @@ export class ErrorOverlay implements IOverlay {
 
             this._showErrors()
         }
+    }
+
+    public showDetails(): void {
+        this._showDetails = true
+        this._showErrors()
+    }
+
+    public hideDetails(): void {
+        this._showDetails = false
+        this._showErrors()
     }
 
     public setErrors(key: string, fileName: string, errors: Oni.Plugin.Diagnostics.Error[], color: string): void {
@@ -64,6 +81,7 @@ export class ErrorOverlay implements IOverlay {
         renderErrorMarkers({
             errors: allErrors,
             windowContext: this._lastWindowContext,
+            showDetails: this._showDetails,
         }, this._element)
     }
 }

--- a/browser/src/UI/Overlay/ErrorOverlay.ts
+++ b/browser/src/UI/Overlay/ErrorOverlay.ts
@@ -18,7 +18,7 @@ export class ErrorOverlay implements IOverlay {
      * In insert mode, we shouldn't show details, because that will overlay completion elements
      * Some LSP providers push error data while changes are being made, whereas others wait until save.
      */
-    private _showDetails: boolean;
+    private _showDetails: boolean
 
     public onVimEvent(_eventName: string, eventContext: Oni.EventContext): void {
 

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -15,6 +15,7 @@ export interface IErrorWithColor extends Oni.Plugin.Diagnostics.Error {
 export interface IErrorsProps {
     errors: IErrorWithColor[]
     windowContext: WindowContext
+    showDetails: boolean
 }
 
 const padding = 8
@@ -38,7 +39,8 @@ export class Errors extends React.Component<IErrorsProps, void> {
                     y={yPos}
                     showTooltipTop={showTooltipTop}
                     text={e.text}
-                    color={e.color}/>
+                    color={e.color}
+                    showDetails={this.props.showDetails} />
             } else {
                 return null
             }
@@ -58,7 +60,7 @@ export class Errors extends React.Component<IErrorsProps, void> {
                     height={this.props.windowContext.fontHeightInPixels}
                     x={startX}
                     width={endX - startX}
-                    color={e.color}/>
+                    color={e.color} />
             } else {
                 return null
             }
@@ -75,6 +77,7 @@ export interface IErrorMarkerProps {
     text: string
     isActive: boolean
     color: string
+    showDetails: boolean
 }
 
 export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
@@ -109,14 +112,14 @@ export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
                 </div>
             </div>) : null
         const errorIcon = <div style={iconPositionStyles} className="error-marker">
-            <div className="icon-container" style={{color: this.props.color}}>
+            <div className="icon-container" style={{ color: this.props.color }}>
                 <Icon name="exclamation-circle" />
             </div>
         </div>
 
         return <div>
-         {errorDescription}
-         {errorIcon}
+            {this.props.showDetails ? errorDescription : null}
+            {errorIcon}
         </div>
     }
 }
@@ -132,7 +135,7 @@ export interface IErrorSquiggleProps {
 export class ErrorSquiggle extends React.Component<IErrorSquiggleProps, void> {
     public render(): JSX.Element {
 
-        const {x, y, width, height, color} = this.props
+        const { x, y, width, height, color } = this.props
 
         const style = {
             top: y.toString() + "px",

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -239,7 +239,13 @@ const start = (args: string[]) => {
             UI.Actions.hideCursorLine()
             UI.Actions.hideCompletions()
             UI.Actions.hideQuickInfo()
+        }
 
+        // Error overlay
+        if (newMode === "insert") {
+            errorOverlay.hideDetails()
+        } else {
+            errorOverlay.showDetails()
         }
     })
 


### PR DESCRIPTION
This change disables the error details while in insert mode, and shows them again in other modes. 

This is really a hack, the better long-term solution is to move the error info to the redux store, and use the information there to gate the rendering. This change unfortunately just adds complexity to the `ErrorOverlay` concept, which is already overly complex, due to how the overlay/window management is implemented. Looking forward to implementing #362 to improve this story.