### PR TITLE
Fix #422 - Get tslint working in release builds

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -2,6 +2,7 @@ import * as cp from "child_process"
 import { remote } from "electron"
 import { EventEmitter } from "events"
 import * as path from "path"
+
 import * as Q from "q"
 import * as Actions from "./actions"
 import * as Config from "./Config"

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -52,11 +52,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         this._languageService = new DebouncedLanguageService(languageService)
     }
 
-    /**
-     * Wrapper around `child_process.exec` to run using electron as opposed to node
-     */
-    public execNodeScript(scriptPath: string, options: ChildProcess.ExecOptions, callback?: (error: Error) => void): ChildProcess.ChildProcess {
-        const executionPath = `"${process.execPath}" "${scriptPath}"`
+    public execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr:string) => void): ChildProcess.ChildProcess {
 
         const requiredOptions = {
             env: {
@@ -69,7 +65,30 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
             ...requiredOptions,
         }
 
-        return ChildProcess.exec(executionPath, opts, callback)
+        const execOptions = [process.execPath, scriptPath].concat(args)
+        const execString = execOptions.map(s => `"${s}"`).join(" ")
+
+        return ChildProcess.exec(execString, opts, callback)
+    }
+
+    /**
+     * Wrapper around `child_process.exec` to run using electron as opposed to node
+     */
+    public spawnNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): ChildProcess.ChildProcess {
+        const requiredOptions = {
+            env: {
+                ELECTRON_RUN_AS_NODE: 1,
+            },
+        }
+
+        const opts = {
+            ...options,
+            ...requiredOptions,
+        }
+
+        const allArgs = [scriptPath].concat(args)
+
+        return ChildProcess.spawn(process.execPath, allArgs, opts)
     }
 
     public setHighlights(file: string, key: string, highlights: Oni.Plugin.SyntaxHighlight[]) {

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -52,8 +52,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         this._languageService = new DebouncedLanguageService(languageService)
     }
 
-    public execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr:string) => void): ChildProcess.ChildProcess {
-
+    public execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess {
         const requiredOptions = {
             env: {
                 ELECTRON_RUN_AS_NODE: 1,
@@ -66,7 +65,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         }
 
         const execOptions = [process.execPath, scriptPath].concat(args)
-        const execString = execOptions.map(s => `"${s}"`).join(" ")
+        const execString = execOptions.map((s) => `"${s}"`).join(" ")
 
         return ChildProcess.exec(execString, opts, callback)
     }

--- a/vim/core/oni-plugin-tslint/lib/index.js
+++ b/vim/core/oni-plugin-tslint/lib/index.js
@@ -5,9 +5,7 @@ const exec = require("child_process").exec
 
 const findParentDir = require("find-parent-dir")
 
-const isWindows = os.platform() === "win32"
-const tslintExecutable = isWindows ? "tslint.cmd" : "tslint"
-const tslintPath = path.join(__dirname, "..", "..", "..", "..", "node_modules", ".bin", tslintExecutable)
+const tslintPath = path.join(__dirname, "..", "..", "..", "..", "node_modules", "tslint", "lib", "tslint-cli.js")
 
 let lastErrors = {}
 let lastArgs = null
@@ -97,12 +95,12 @@ const activate = (Oni) => {
             processArgs = processArgs.concat(["--fix"])
         }
 
-        processArgs = processArgs.concat(["--force", "--format json"])
+        processArgs = processArgs.concat(["--force", "--format", "json"])
 
-        processArgs.push("--config", path.join(configPath, "tslint.json"))
+        processArgs = processArgs.concat(["--config", path.join(configPath, "tslint.json")])
         processArgs = processArgs.concat(args)
 
-        return Q.nfcall(exec, tslintPath + " " + processArgs.join(" "), { cwd: workingDirectory })
+        return Q.nfcall(Oni.execNodeScript, tslintPath, processArgs, { cwd: workingDirectory })
             .then((stdout, stderr) => {
 
                 const errorOutput = stdout.join(os.EOL).trim()

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -39,11 +39,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
         // This has some info on using eventPort: https://github.com/Microsoft/TypeScript/blob/master/src/server/server.ts
         // which might be more reliable
         // Can create the port using this here: https://github.com/Microsoft/TypeScript/blob/master/src/server/server.ts
-        this._tssProcess = Oni.execNodeScript(tssPath, { maxBuffer: 500 * 1024 * 1024 }, (err) => {
-            if (err) {
-                console.error(err)
-            }
-        })
+        this._tssProcess = Oni.spawnNodeScript(tssPath)
         console.log("Process ID: " + this._tssProcess.pid) // tslint:disable-line no-console
 
         this._rl = readline.createInterface({

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -24,7 +24,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
         return this._tssProcess.pid
     }
 
-    constructor() {
+    constructor(Oni: any) {
         super()
 
         // Other tries for creating process:
@@ -39,7 +39,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
         // This has some info on using eventPort: https://github.com/Microsoft/TypeScript/blob/master/src/server/server.ts
         // which might be more reliable
         // Can create the port using this here: https://github.com/Microsoft/TypeScript/blob/master/src/server/server.ts
-        this._tssProcess = childProcess.exec(`node "${tssPath}"`, { maxBuffer: 500 * 1024 * 1024 }, (err) => {
+        this._tssProcess = Oni.execNodeScript(tssPath, { maxBuffer: 500 * 1024 * 1024 }, (err) => {
             if (err) {
                 console.error(err)
             }

--- a/vim/core/oni-plugin-typescript/src/index.ts
+++ b/vim/core/oni-plugin-typescript/src/index.ts
@@ -24,7 +24,7 @@ export interface IDisplayPart {
 
 export const activate = (Oni) => {
 
-    const host = new TypeScriptServerHost()
+    const host = new TypeScriptServerHost(Oni)
     const quickInfo = new QuickInfo(Oni, host)
 
     const lastOpenFile = null


### PR DESCRIPTION
There were a couple issues preventing tslint from working in release builds:

__Issue 1__: Depending on `node` command being available in `%PATH%`.
__Issue 2__: Parameters were not wrapped with quotes, so if there was a space in the pathname, there would be issues.

This fix adds some API methods - `Oni.spawnNodeScript` and `Oni.execNodeScript` to handle these for various in-built plugins.