### PR TITLE
Fix #426: Use common utility for spawning script

### DIFF
--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -9,7 +9,7 @@ import * as _ from "lodash"
 import * as rpc from "vscode-jsonrpc"
 import * as types from "vscode-languageserver-types"
 
-import { ChildProcess, exec } from "child_process"
+import { ChildProcess } from "child_process"
 
 import { getCompletionMeet } from "./../../../Services/AutoCompletionUtility"
 import { Oni } from "./../Oni"
@@ -107,12 +107,8 @@ export class LanguageClient {
     public start(initializationParams: LanguageClientInitializationParams): Thenable<any> {
 
         // TODO: Pursue alternate connection mechanisms besides stdio - maybe Node IPC?
-        this._process = exec(`"${process.execPath}" "${this._startCommand}"`, { maxBuffer: 500 * 1024 * 1024, env: { ELECTRON_RUN_AS_NODE: 1 } }, (err) => {
-            if (err) {
-                console.error(err)
-                alert(err)
-            }
-        })
+
+        this._process = this._oni.spawnNodeScript(this._startCommand)
 
         this._connection = rpc.createMessageConnection(
             <any>(new rpc.StreamMessageReader(this._process.stdout)),

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -25,9 +25,9 @@ export const ProtocolConstants = {
     },
 }
 
-export const wrapPathInFileUri = (path: string) => "file:///" + path
+export const wrapPathInFileUri = (path: string) => "file://" + path
 
-export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file:///")[1])
+export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file://")[1])
 
 export const bufferUpdateToTextDocumentItem = (args: Oni.BufferUpdateContext): types.TextDocumentItem => {
     const lines = args.bufferLines

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -25,9 +25,9 @@ export const ProtocolConstants = {
     },
 }
 
-export const wrapPathInFileUri = (path: string) => "file://" + path
+export const wrapPathInFileUri = (path: string) => "file:///" + path
 
-export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file://")[1])
+export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file:///")[1])
 
 export const bufferUpdateToTextDocumentItem = (args: Oni.BufferUpdateContext): types.TextDocumentItem => {
     const lines = args.bufferLines

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -55,6 +55,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
     public execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess {
         const requiredOptions = {
             env: {
+                ...process.env,
                 ELECTRON_RUN_AS_NODE: 1,
             },
         }
@@ -76,6 +77,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
     public spawnNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): ChildProcess.ChildProcess {
         const requiredOptions = {
             env: {
+                ...process.env,
                 ELECTRON_RUN_AS_NODE: 1,
             },
         }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "license": "MIT",
   "dependencies": {
     "find-parent-dir": "0.3.0",
+    "lodash": "4.17.0",
     "minimist": "1.2.0",
     "neovim-client": "2.1.0",
     "omnisharp-client": "7.0.6",
@@ -122,7 +123,6 @@
     "less": "2.7.1",
     "less-loader": "2.2.3",
     "less-plugin-autoprefix": "1.5.1",
-    "lodash": "4.17.0",
     "mkdirp": "0.5.1",
     "mocha": "3.1.2",
     "optimize-js-plugin": "0.0.4",


### PR DESCRIPTION
- Use the common `spawnNodeScript` utility for spawning the language service
- Pass along environment variables to spawned processes