### PR TITLE
Fix #427 - Add better error messages for tslint, and add missing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "neovim-client": "2.1.0",
     "omnisharp-client": "7.0.6",
     "q": "1.4.1",
+    "tslint": "4.0.2",
     "typescript": "2.2.1"
   },
   "devDependencies": {
@@ -137,7 +138,6 @@
     "sinon": "1.17.6",
     "style-loader": "0.13.1",
     "ts-loader": "1.2.2",
-    "tslint": "4.0.2",
     "vscode-jsonrpc": "3.2.0",
     "vscode-languageserver-types": "3.2.0",
     "wcwidth": "1.0.1",

--- a/vim/core/oni-plugin-tslint/lib/index.js
+++ b/vim/core/oni-plugin-tslint/lib/index.js
@@ -131,7 +131,7 @@ const activate = (Oni) => {
                 }, {})
 
                 return errors
-            })
+            }, (err) => console.error(err))
     }
 
     function getCurrentWorkingDirectory(args) {


### PR DESCRIPTION
Fix #427 - add better error messages for tslint. 

Adding this identified that the `tslint` module was missing from the dependencies in the bundled package.