### PR TITLE
Add node_modules caching for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,17 @@ addons:
 
 install:
     - npm install
+
 script:
     - npm run build
     - npm run test
     - npm run lint
     - npm run pack
+
+cache:
+  directories:
+    - node_modules
+
 deploy:
     - provider: releases
       api_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 environment:
   nodejs_version: "6"
 
+cache:
+  - node_modules -> package.json
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js


### PR DESCRIPTION
Both travisCI and appveyor have caching options for node_modules. This helps to speed up build times, because installing node_modules takes a disproportionate amount of time.