### PR TITLE
Fix #443: Implement fixes to support Go langserver (generalize language server support)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,9 +1,0 @@
-- Set up initialization path to differentiate between a node script starting and a shell executable
-- Need configuration variables to be passed to plugin?
-
-
-interface ServerOptions {
-    shellCmd?: string
-    module?: string
-    args?: string[]
-}

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,2 @@
+- Set up initialization path to differentiate between a node script starting and a shell executable
+- Need configuration variables to be passed to plugin?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,2 +1,9 @@
 - Set up initialization path to differentiate between a node script starting and a shell executable
 - Need configuration variables to be passed to plugin?
+
+
+interface ServerOptions {
+    shellCmd?: string
+    module?: string
+    args?: string[]
+}

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ _Known Issues_
 
 _Configuration_
 
-Go language support depends on the [Go langserver](https://github.com/sourcegraph/go-langserver) by SourceGraph, which provides language support for Go.
+Go language support depends on the [Go langserver](https://github.com/sourcegraph/go-langserver) by SourceGraph, which provides language support for Go. Follow their installation instructions as this language server is not bundled out-of-the-box with Oni.
 
-> Make sure that `go-langserver` is available in your PATH (accessible from the terminal) in order to leverage the language service in Oni.
+> `go-langserver` must be available in your PATH
 
 _Supported Language features_
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - [Languages](#languages)
         - [JavaScript and TypeScript](#javascript-and-typescript)
         - [C#](c)
+        - [Go](go)
     - [Configuration](#configuration)
     - [Extensibility](#extensibility)
     - [FAQ](#faq)
@@ -242,6 +243,24 @@ _Known Issues_
 
 - On Windows, you must run Oni as an administrator the first time using the C# language service. This is tracked by issue [#423](https://github.com/extr0py/oni/issues/423).
 - On all platforms, the C# language service takes time to start up, especially the first time as it is downloading the appropriate runtime environment. You can open up the developer tools (Help -> Developer Tools) to see the logging from the language service. [#424](https://github.com/extr0py/oni/issues/424) tracks making this logging more visible.
+
+#### Go
+
+_Configuration_
+
+Go language support depends on the [Go langserver](https://github.com/sourcegraph/go-langserver) by SourceGraph, which provides language support for Go.
+
+> Make sure that `go-langserver` is available in your PATH (accessible from the terminal) in order to leverage the language service in Oni.
+
+_Supported Language features_
+
+| Completion | Goto Definition | Formatting | Enhanced Syntax Highlighting | Quick Info | Signature Help | Live Evaluation | Debugging |
+| --- | --- | --- | --- | --- | --- |--- | --- |
+| N | Y | N | N | Y | N | N | N |
+
+_Known Issues_
+
+- There is no Windows support at the moment - this is being tracked by [sourcegraph/go-langserver#113](https://github.com/sourcegraph/go-langserver/issues/113).
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
         - [Quick Info](#quick-info)
     - [Languages](#languages)
         - [JavaScript and TypeScript](#javascript-and-typescript)
-        - [C#](c)
-        - [Go](go)
+        - [C#](#c)
+        - [Go](#go)
     - [Configuration](#configuration)
     - [Extensibility](#extensibility)
     - [FAQ](#faq)
@@ -248,7 +248,7 @@ _Known Issues_
 
 _Configuration_
 
-Go language support depends on the [Go langserver](https://github.com/sourcegraph/go-langserver) by SourceGraph, which provides language support for Go. Follow their installation instructions as this language server is not bundled out-of-the-box with Oni.
+Go language support depends on the [go-langserver](https://github.com/sourcegraph/go-langserver) by [SourceGraph](https://sourcegraph.com), which provides language support for Go. Follow their installation instructions as this language server is not bundled out-of-the-box with Oni.
 
 > `go-langserver` must be available in your PATH
 

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -243,13 +243,22 @@ export class LanguageClient {
                     return null
                 }
 
-                let contents = result.contents.toString().trim()
+                let contents = Helpers.getTextFromContents(result.contents)
 
                 if (contents.length === 0) {
                     return null
+                } else if (contents.length === 1) {
+                    return {
+                        title: contents[0],
+                        description: "",
+                    }
+                } else {
+                    return {
+                        title: contents[0],
+                        description: contents[1],
+                    }
                 }
 
-                return { title: contents, description: "" }
             })
     }
 

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -248,8 +248,14 @@ export class LanguageClient {
                 if (contents.length === 0) {
                     return null
                 } else if (contents.length === 1) {
+                    const title = contents[0]
+
+                    if (!title) {
+                        return null
+                    }
+
                     return {
-                        title: contents[0],
+                        title,
                         description: "",
                     }
                 } else {

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -17,6 +17,32 @@ import { Oni } from "./../Oni"
 import * as Helpers from "./LanguageClientHelpers"
 import { LanguageClientLogger } from "./LanguageClientLogger"
 
+/**
+ * Options for starting the Language Server process
+ */
+export interface ServerRunOptions {
+    /**
+     * Specify `command` to use a shell command to spawn a process
+     */
+    command?: string
+
+    /**
+     * Specify `module` to run a JavaScript module
+     */
+    module?: string
+
+    /**
+     * Arguments to pass to the language servicew
+     */
+    args?: string[]
+
+    // TODO: TransportKind option?
+}
+
+/**
+ * Options to send to the `initialize` method of the 
+ * Language Server
+ */
 export interface LanguageClientInitializationParams {
     clientName: string
     rootPath: string
@@ -44,7 +70,7 @@ export class LanguageClient {
     private _initializationParams: LanguageClientInitializationParams
 
     constructor(
-        private _startCommand: string,
+        private _startOptions: ServerRunOptions,
         private _initializationParamsCreator: InitializationParamsCreator,
         private _oni: Oni) {
 
@@ -100,11 +126,15 @@ export class LanguageClient {
     }
 
     public start(initializationParams: LanguageClientInitializationParams): Thenable<any> {
+        const startArgs = this._startOptions.args || []
 
-        // TODO: Pursue alternate connection mechanisms besides stdio - maybe Node IPC?
-
-        // this._process = this._oni.spawnNodeScript(this._startCommand)
-        this._process = spawn(this._startCommand)
+        if (this._startOptions.command) {
+            this._process = spawn(this._startOptions.command, startArgs)
+        } else if (this._startOptions.module) {
+            this._process = this._oni.spawnNodeScript(this._startOptions.module, startArgs)
+        } else {
+            throw "A command or module must be specified to start the server"
+        }
 
         this._connection = rpc.createMessageConnection(
             <any>(new rpc.StreamMessageReader(this._process.stdout)),
@@ -210,13 +240,13 @@ export class LanguageClient {
             Helpers.eventContextToTextDocumentPositionParams(textDocumentPosition))
             .then((result: types.Hover) => {
                 if (!result || !result.contents) {
-                    throw "No quickinfo available"
+                    return null
                 }
 
                 let contents = result.contents.toString().trim()
 
                 if (contents.length === 0) {
-                    throw "Quickinfo data empty"
+                    return null
                 }
 
                 return { title: contents, description: "" }
@@ -226,10 +256,19 @@ export class LanguageClient {
     private _getDefinition(textDocumentPosition: Oni.EventContext): Thenable<Oni.Plugin.GotoDefinitionResponse> {
         return this._connection.sendRequest(Helpers.ProtocolConstants.TextDocument.Definition,
             Helpers.eventContextToTextDocumentPositionParams(textDocumentPosition))
-            .then((result: types.Location) => {
-                const startPos = result.range.start || result.range.end
+            .then((result: types.Location & types.Location[]) => {
+                if (!result) {
+                    return null
+                }
+
+                let location: types.Location = result
+                if (result.length) {
+                    location = result[0]
+                }
+
+                const startPos = location.range.start || location.range.end
                 return {
-                    filePath: Helpers.unwrapFileUriPath(result.uri),
+                    filePath: Helpers.unwrapFileUriPath(location.uri),
                     line: startPos.line + 1,
                     column: startPos.character + 1,
                 }

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -25,9 +25,9 @@ export const ProtocolConstants = {
     },
 }
 
-export const wrapPathInFileUri = (path: string) => "file://" + path
+export const wrapPathInFileUri = (path: string) => getFilePrefix() + path
 
-export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file://")[1])
+export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split(getFilePrefix())[1])
 
 export const getTextFromContents = (contents: types.MarkedString | types.MarkedString[]): string[] => {
     if (contents instanceof Array) {
@@ -35,15 +35,6 @@ export const getTextFromContents = (contents: types.MarkedString | types.MarkedS
                 .map((markedString) => getTextFromMarkedString(markedString))
     } else {
         return [getTextFromMarkedString(contents)]
-    }
-}
-
-const getTextFromMarkedString = (markedString: types.MarkedString): string => {
-    if (typeof markedString === "string") {
-        return markedString.trim()
-    } else {
-        // TODO: Properly apply syntax highlighting based on the `language` parameter
-        return markedString.value.trim()
     }
 }
 
@@ -100,5 +91,23 @@ export const incrementalBufferUpdateToDidChangeTextDocumentParams = (args: Oni.I
             range: types.Range.create(lineNumber - 1, 0, lineNumber - 1, previousLineLength),
             text: changedLine,
         }],
+    }
+}
+
+const getTextFromMarkedString = (markedString: types.MarkedString): string => {
+    if (typeof markedString === "string") {
+        return markedString.trim()
+    } else {
+        // TODO: Properly apply syntax highlighting based on the `language` parameter
+        return markedString.value.trim()
+    }
+}
+
+
+const getFilePrefix = () => {
+    if (process.platform === "win32") {
+        return "file://"
+    } else {
+        return "file:///"
     }
 }

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -40,10 +40,10 @@ export const getTextFromContents = (contents: types.MarkedString | types.MarkedS
 
 const getTextFromMarkedString = (markedString: types.MarkedString): string => {
     if (typeof markedString === "string") {
-        return markedString
+        return markedString.trim()
     } else {
         // TODO: Properly apply syntax highlighting based on the `language` parameter
-        return markedString.value
+        return markedString.value.trim()
     }
 }
 

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -25,9 +25,9 @@ export const ProtocolConstants = {
     },
 }
 
-export const wrapPathInFileUri = (path: string) => "file:///" + path
+export const wrapPathInFileUri = (path: string) => "file://" + path
 
-export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file:///")[1])
+export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file://")[1])
 
 export const bufferUpdateToTextDocumentItem = (args: Oni.BufferUpdateContext): types.TextDocumentItem => {
     const lines = args.bufferLines

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -103,7 +103,6 @@ const getTextFromMarkedString = (markedString: types.MarkedString): string => {
     }
 }
 
-
 const getFilePrefix = () => {
     if (process.platform === "win32") {
         return "file://"

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -29,6 +29,24 @@ export const wrapPathInFileUri = (path: string) => "file://" + path
 
 export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split("file://")[1])
 
+export const getTextFromContents = (contents: types.MarkedString | types.MarkedString[]): string[] => {
+    if (contents instanceof Array) {
+        return contents
+                .map((markedString) => getTextFromMarkedString(markedString))
+    } else {
+        return [getTextFromMarkedString(contents)]
+    }
+}
+
+const getTextFromMarkedString = (markedString: types.MarkedString): string => {
+    if (typeof markedString === "string") {
+        return markedString
+    } else {
+        // TODO: Properly apply syntax highlighting based on the `language` parameter
+        return markedString.value
+    }
+}
+
 export const bufferUpdateToTextDocumentItem = (args: Oni.BufferUpdateContext): types.TextDocumentItem => {
     const lines = args.bufferLines
     const { bufferFullPath, filetype, version } = args.eventContext

--- a/vim/core/oni-plugin-csharp/lib/index.js
+++ b/vim/core/oni-plugin-csharp/lib/index.js
@@ -9,9 +9,11 @@ const activate = (Oni) => {
 
     const omniSharpLangServerPath = path.join(__dirname, "..", "..", "..", "..", "node_modules", "omnisharp-client", "languageserver", "server.js")
 
-    const execCommand = `${omniSharpLangServerPath}`
+    const startOptions = {
+        module: `${omniSharpLangServerPath}`
+    }
 
-    const client = Oni.createLanguageClient(execCommand, (filePath) => {
+    const client = Oni.createLanguageClient(startOptions, (filePath) => {
         return getRootProjectFileAsync(path.dirname(filePath))
             .then((csprojPath) => {
                 return {

--- a/vim/core/oni-plugin-golang/index.js
+++ b/vim/core/oni-plugin-golang/index.js
@@ -6,7 +6,11 @@ const _ = require("lodash")
 const rpc = require("vscode-jsonrpc")
 
 const activate = (Oni) => {
-    const client = Oni.createLanguageClient("C:/users/bryan/go/bin/go-langserver.exe", (filePath) => {
+    const serverOptions = {
+        command: path.join(process.env.HOME, "go", "bin", "go-langserver")
+    }
+
+    const client = Oni.createLanguageClient(serverOptions, (filePath) => {
                 return Promise.resolve({
                     clientName: "go-langserver",
                     rootPath: "file:///" + path.dirname(filePath).split("\\").join("/"),

--- a/vim/core/oni-plugin-golang/index.js
+++ b/vim/core/oni-plugin-golang/index.js
@@ -7,7 +7,7 @@ const rpc = require("vscode-jsonrpc")
 
 const activate = (Oni) => {
     const serverOptions = {
-        command: path.join(process.env.HOME, "go", "bin", "go-langserver")
+        command: "go-langserver",
     }
 
     const client = Oni.createLanguageClient(serverOptions, (filePath) => {

--- a/vim/core/oni-plugin-golang/index.js
+++ b/vim/core/oni-plugin-golang/index.js
@@ -6,51 +6,15 @@ const _ = require("lodash")
 const rpc = require("vscode-jsonrpc")
 
 const activate = (Oni) => {
-    const client = Oni.createLanguageClient("go-langserver", (filePath) => {
-        return getRootProjectFileAsync(path.dirname(filePath))
-            .then((csprojPath) => {
-                return {
+    const client = Oni.createLanguageClient("C:/users/bryan/go/bin/go-langserver.exe", (filePath) => {
+                return Promise.resolve({
                     clientName: "go-langserver",
-                    rootPath: csprojPath,
+                    rootPath: "file:///" + path.dirname(filePath).split("\\").join("/"),
                     capabilities: {
                         highlightProvider: true
                     }
-                }
+                })
             })
-    });
-
-}
-
-const getFilesForDirectoryAsync = (fullPath) => {
-    return new Promise((resolve, reject) => {
-        fs.readdir(fullPath, (err, files) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve(files)
-            }
-        })
-    })
-}
-
-const getRootProjectFileAsync = (fullPath) => {
-
-    const parentDir = path.dirname(fullPath)
-
-    if (parentDir === fullPath) {
-        return Promise.reject("Unable to find go-root")
-    }
-
-    return getFilesForDirectoryAsync(fullPath)
-        .then((files) => {
-            const proj = _.find(files, (f) => f.indexOf(".go") >= 0)
-
-            if (proj) {
-                return fullPath
-            } else {
-                return getRootProjectFileAsync(path.dirname(fullPath))
-            }
-        })
 }
 
 module.exports = {

--- a/vim/core/oni-plugin-golang/index.js
+++ b/vim/core/oni-plugin-golang/index.js
@@ -1,0 +1,58 @@
+const fs = require("fs")
+const path = require("path")
+const childProcess = require("child_process")
+
+const _ = require("lodash")
+const rpc = require("vscode-jsonrpc")
+
+const activate = (Oni) => {
+    const client = Oni.createLanguageClient("go-langserver", (filePath) => {
+        return getRootProjectFileAsync(path.dirname(filePath))
+            .then((csprojPath) => {
+                return {
+                    clientName: "go-langserver",
+                    rootPath: csprojPath,
+                    capabilities: {
+                        highlightProvider: true
+                    }
+                }
+            })
+    });
+
+}
+
+const getFilesForDirectoryAsync = (fullPath) => {
+    return new Promise((resolve, reject) => {
+        fs.readdir(fullPath, (err, files) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(files)
+            }
+        })
+    })
+}
+
+const getRootProjectFileAsync = (fullPath) => {
+
+    const parentDir = path.dirname(fullPath)
+
+    if (parentDir === fullPath) {
+        return Promise.reject("Unable to find go-root")
+    }
+
+    return getFilesForDirectoryAsync(fullPath)
+        .then((files) => {
+            const proj = _.find(files, (f) => f.indexOf(".go") >= 0)
+
+            if (proj) {
+                return fullPath
+            } else {
+                return getRootProjectFileAsync(path.dirname(fullPath))
+            }
+        })
+}
+
+module.exports = {
+    activate
+}

--- a/vim/core/oni-plugin-golang/package.json
+++ b/vim/core/oni-plugin-golang/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "oni-plugin-golang",
+    "version": "0.0.1",
+    "main": "index.js",
+    "engines": {
+        "oni": "^0.2.2"
+    },
+    "scripts": {
+        "build": "npm install && tsc",
+        "test": "npm install && tsc -p tsconfig.test.json && mocha --recursive ./lib_test/test"
+    },
+    "oni": {
+        "supportedFileTypes": [
+            "go"
+        ],
+        "subscriptions": [
+            "buffer-update",
+            "vim-events"
+        ],
+        "languageService": [
+            "quick-info",
+            "goto-definition",
+            "completion-provider",
+            "find-all-references",
+            "formatting",
+            "evaluate-block",
+            "signature-help"
+        ],
+        "diagnosticsService": []
+    },
+    "dependencies": {},
+    "devDependencies": {}
+}


### PR DESCRIPTION
This implements several improvements to the Language Service in order to support other language services.

- Generalize the language client initialize to support either running a shell command (which is needed for running the python, go, rust, etc language services), or a script module (omnisharp, typescript, etc).
- Update QuickInfo to further support `MarkedString`.
- Fix bug in go-to definition on OSX / Linux to properly support file paths.
- Remove the `getHighlights` call which isn't supported by any language service for now - it seems like this is causing a crash in the go language service

There are a couple of caveats with this service:
- The Go language service doesn't seem to support Windows yet (sourcegraph/go-langserver#113).
- Completion isn't currently not supported.
- Looks like highlighting via keywords could be supported,  but still need #379 implemented on the Oni side to support this.