### PR TITLE
Fix for #460: Close only single instance

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -154,7 +154,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 })
 
                 this._neovim.on("disconnect", () => {
-                    remote.app.quit()
+                    remote.getCurrentWindow().close()
                 })
 
                 const startupOptions = {


### PR DESCRIPTION
__Issue:__ When using `:q` to close the app, all open Oni windows also close. This is very frustrating and annoying.

__Defect:__ The app uses electron's `makeSingleInstance` functionality, which means there is only one 'main' process and multiple 'browser' processes. When using `remote.app.quit()` this would close _all_ instances.

__Fix:__ When an individual instance quits, just close the browser window instead of killing the whole app and all browser windows.