### PR TITLE
UI: Remove border from Menu/QuickInfo/Completion

### DIFF
--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -18,10 +18,10 @@
 
             .main {
                 opacity: 1;
+            }
 
-                .icon {
-                    border-left: 1px solid white;
-                }
+            .detail {
+                visibility: visible;
             }
         }
 
@@ -37,6 +37,7 @@
                 width: 20px;
                 flex: 0 0 auto;
                 color: white;
+                text-align: center;
 
                 i {
                     margin-left: 4px;
@@ -71,6 +72,7 @@
             color: @text-color-detail;
 
             font-size: 11px;
+            visibility: hidden;
         }
 
         .documentation {

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -1,8 +1,9 @@
 @import (reference) "./common.less";
 
 .autocompletion {
+    .box-shadow;
+
     background-color: @background-color;
-    box-shadow: 4px 4px @shadow-color;
     color: @text-color;
     max-width: 800px;
     max-height: 300px;
@@ -13,8 +14,8 @@
 
     .entry {
         &.selected {
+            .box-shadow;
             background-color: rgb(60, 60, 60);
-            box-shadow: 4px 4px @shadow-color;
 
             .main {
                 opacity: 1;

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -2,7 +2,6 @@
 
 .autocompletion {
     background-color: @background-color;
-    border: 1px solid gray;
     box-shadow: 4px 4px @shadow-color;
     color: @text-color;
     max-width: 800px;

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -14,6 +14,7 @@
     .entry {
         &.selected {
             background-color: rgb(60, 60, 60);
+            box-shadow: 4px 4px @shadow-color;
 
             .main {
                 opacity: 1;

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -74,7 +74,6 @@ export class AutoCompletionItem extends React.Component<IAutoCompletionItemProps
             className += " selected"
         }
 
-        const detailToShow = this.props.isSelected ? this.props.detail : ""
         const documentation = this.props.isSelected ? this.props.documentation : ""
 
         const highlightColor = this.props.highlightColor || this._getDefaultHighlightColor(this.props.kind as any) // FIXME: undefined
@@ -89,7 +88,7 @@ export class AutoCompletionItem extends React.Component<IAutoCompletionItemProps
                     <AutoCompletionIcon kind={this.props.kind as any /* FIXME: undefined */} />
                 </span>
                 <HighlightText className="label" highlightClassName="highlight" highlightText={this.props.base} text={this.props.label} />
-                <span className="detail">{detailToShow}</span>
+                <span className="detail">{this.props.detail}</span>
             </div>
             <div className="documentation">{documentation}</div>
         </div>

--- a/browser/src/UI/components/Error.less
+++ b/browser/src/UI/components/Error.less
@@ -32,12 +32,13 @@
 }
 
 .error {
+    .box-shadow;
+
     opacity: 0;
     flex: 1 1 auto;
     transition: opacity 0.2s;
     position: absolute;
     background-color: @background-color;
-    box-shadow: 3px 3px @shadow-color;
     border-left: 7px solid;
     padding: 6px;
     margin-top: 31px;

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -13,13 +13,12 @@
 }
 
 .menu {
+    .box-shadow;
+
     margin-top: 16px;
     background-color: @background-color;
     color: @text-color;
-
     padding: 8px;
-
-    box-shadow: 4px 4px @shadow-color;
     width: 600px;
     max-height: 400px;
 
@@ -55,8 +54,8 @@
                 background-color: fade(@background-color-highlight, 10%);
             }
             &.selected {
+                .box-shadow;
                 background-color: @background-color-highlight;
-                box-shadow: 4px 4px @shadow-color;
             }
 
             .label {

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -17,7 +17,6 @@
     background-color: @background-color;
     color: @text-color;
 
-    border: 1px solid rgb(60, 60, 60);
     padding: 8px;
 
     box-shadow: 4px 4px @shadow-color;
@@ -57,6 +56,7 @@
             }
             &.selected {
                 background-color: @background-color-highlight;
+                box-shadow: 4px 4px @shadow-color;
             }
 
             .label {

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -7,7 +7,6 @@
 
     .quickinfo {
         background-color: @background-color;
-        border: 1px solid gray;
         padding: 4px;
         box-shadow: 4px 4px @shadow-color;
         color: @text-color;

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -6,9 +6,10 @@
     animation-duration: 0.5s;
 
     .quickinfo {
+        .box-shadow;
+
         background-color: @background-color;
         padding: 4px;
-        box-shadow: 4px 4px @shadow-color;
         color: @text-color;
         text-overflow: ellipsis;
         overflow: hidden;

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -54,3 +54,7 @@
         flex: 0 0 auto;
     }
 }
+
+.box-shadow {
+  box-shadow: 0 4px 8px 2px rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}


### PR DESCRIPTION
After spending time with @FrigoEU 's improvements to the error UI, I really liked the borderless style of the UI elements, and extended that to some of the other elements:

![borderless](https://cloud.githubusercontent.com/assets/13532591/26358242/c2181372-3f86-11e7-91ed-e3cbd45d4726.gif)

And use the drop shadow to have a layering / depth effect.

The 'flicker' of the completion menu needs to be fixed as well - using #463 to track that.