### PR TITLE
Fix #376, off-by-one in autocomplete substring

### DIFF
--- a/browser/src/Services/AutoCompletionUtility.ts
+++ b/browser/src/Services/AutoCompletionUtility.ts
@@ -8,10 +8,10 @@ export function getCompletionStart(bufferLine: string, cursorColumn: number, com
 
     cursorColumn = Math.min(cursorColumn, bufferLine.length)
 
-    let x = cursorColumn - 1
+    let x = cursorColumn
     while (x >= 0) {
 
-        const subWord = bufferLine.substring(x, cursorColumn)
+        const subWord = bufferLine.substring(x, cursorColumn + 1)
 
         if (completion.indexOf(subWord) === -1) {
             break


### PR DESCRIPTION
Oni's autocomplete feature works by taking the selected item (e.g., `addEventListener`) and removing the subset of characters already typed (e.g., `add`).  Unfortunately, if no subset was provided it would delete the last typed character (#376).  This is because there was an off-by-one error where we were always starting at the character *before* the cursor.  So when given `add` we were looking for `ad`.  This works fine when there are extra characters to lose but when the substring is `""` we were stepping the cursor back one character and *then* searching for the substring, which would lose that previous character.

The fix for this defect is to step one character forward to include the character under the cursor rather than moving one character backward in the initial case.