### PR TITLE
Fix #453: Prevent text from wrapping in editor elements

### DIFF
--- a/browser/src/Renderer/ElementFactory.ts
+++ b/browser/src/Renderer/ElementFactory.ts
@@ -32,6 +32,7 @@ export class RecycleElementFactory {
         }
 
         const elem = document.createElement("span")
+        elem.style.whiteSpace = "nowrap"
         this._rootElement.appendChild(elem)
         return elem
     }


### PR DESCRIPTION
**Issue**: In some cases, the spans for text content are sized just a bit too small, causing the text to wrap

**Defect**: It seems that in some cases, with fractional fonts, there are fractional errors in the calculation that cause the element to be sized just a bit too small. This does not reproduce for all fonts / environments.

**Fix**: Experimented with a few different ways to fix this:
- Add a buffer to the element (using `Math.ceil` for the calculation). This didn't work in all cases
- Add `whitespace: nowrap` to the elements to prevent wrapping

The latter fix seemed to work reliably, and there was not a performance regression based on my testing, so I went with that scoped fix.