### PR TITLE
Fix #372, use readFile() to load plugins rather than readFileSync()

### DIFF
--- a/browser/src/Plugins/Plugin.ts
+++ b/browser/src/Plugins/Plugin.ts
@@ -30,21 +30,20 @@ export class Plugin {
         const packageJsonPath = path.join(this._pluginRootDirectory, "package.json")
         this._channel = channel
 
-        if (fs.existsSync(packageJsonPath)) {
-            this._oniPluginMetadata = PackageMetadataParser.parseFromString(fs.readFileSync(packageJsonPath, "utf8"))
+        fs.readFile(packageJsonPath, "utf8", (err, data) => {
+            if ( ! err) {
+                this._oniPluginMetadata = PackageMetadataParser.parseFromString(data)
 
-            if (!this._oniPluginMetadata) {
-                Log.error(`[PLUGIN] Aborting plugin load, invalid package.json: ${packageJsonPath}`)
-            } else {
-                if (this._oniPluginMetadata.main) {
-
+                if (!this._oniPluginMetadata) {
+                    Log.error(`[PLUGIN] Aborting plugin load, invalid package.json: ${packageJsonPath}`)
+                } else if (this._oniPluginMetadata.main) {
                     this._oni = new Oni(this._channel.createPluginChannel(this._oniPluginMetadata,
                         () => this._onActivate()))
 
                     this._commands = PackageMetadataParser.getAllCommandsFromMetadata(this._oniPluginMetadata)
                 }
             }
-        }
+        })
     }
 
     private _onActivate(): void {


### PR DESCRIPTION
In #372, you recommended using a Promise rather than two synchronous calls to `fs` (`existsSync` and `readFileSync`).  However, the docs for [File System](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback) say:
> Using fs.exists() to check for the existence of a file before calling fs.open(), fs.readFile() or fs.writeFile() is not recommended. Doing so introduces a race condition, since other processes may change the file's state between the two calls. Instead, user code should open/read/write the file directly and handle the error raised if the file does not exist.

So instead of refactoring to use a Promise I removed the call to `exists` and just call `readFile` (not `readFileSync`) to make it asynchronous.  I didn't profile it to test whether this solution is faster and I also don't know if there are any benefits to a Promise which an asynchronous call does not provide.  So let me know if this solution isn't acceptable.  I did test the change though and it seems to work as far as I can tell.