### PR TITLE
Fix #369, replace findParentDir.sync with Promise

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -120,7 +120,7 @@
 - LaunchService
     - Create test plugin to exercise this functionality
     - Launch command: editor.launch
-    - Use find-parent-dir module to search upward
+    - Use find-up module to search upward
     - Implement this functionality in a plugin
     - Oni.registerCommand("editor.launch", () => { Oni.editor.executeShellCommand(...) })
     - Use mapping to bind to editor.launch

--- a/browser/src/ProjectConfig.ts
+++ b/browser/src/ProjectConfig.ts
@@ -39,27 +39,27 @@ const DefaultConfiguration: IProjectConfiguration = {
  * Search upward for the relevant .oni folder
  */
 export function getProjectConfiguration(filePath: string): Q.Promise<IProjectConfiguration> {
-    const oniDir = findUp.sync(".oni", { cwd: filePath })
-
-    if (!oniDir) {
-        return Q(DefaultConfiguration)
-    }
-
-    return loadConfigurationFromFolder(oniDir)
+    return findUp(".oni", { cwd: filePath })
+    .then((oniDir: string) => {
+        if (!oniDir) {
+            return DefaultConfiguration
+        }
+        return loadConfigurationFromFolder(oniDir)
+    })
 }
 
-function loadConfigurationFromFolder(folder: string): Q.Promise<IProjectConfiguration> {
+function loadConfigurationFromFolder(folder: string): IProjectConfiguration {
 
     const launchPath = path.join(folder, "launch.json")
 
     if (!fs.existsSync(launchPath)) {
-        return Q(DefaultConfiguration)
+        return DefaultConfiguration
     } else {
        const launchInfo: ILaunchConfiguration = JSON.parse(fs.readFileSync(launchPath, "utf8"))
        const config = {...DefaultConfiguration, ...{
            launchConfigurations: [launchInfo],
        }}
 
-       return Q(config)
+       return config
     }
 }

--- a/browser/src/ProjectConfig.ts
+++ b/browser/src/ProjectConfig.ts
@@ -9,7 +9,7 @@ import * as path from "path"
 
 import * as Q from "q"
 
-const findParentDir = require("find-parent-dir") // tslint:disable-line no-var-requires
+const findUp = require("find-up") // tslint:disable-line no-var-requires
 
 export type LaunchType = "execute"
 export type Request = "launch" // attach later
@@ -39,13 +39,13 @@ const DefaultConfiguration: IProjectConfiguration = {
  * Search upward for the relevant .oni folder
  */
 export function getProjectConfiguration(filePath: string): Q.Promise<IProjectConfiguration> {
-    const oniDir = findParentDir.sync(filePath, ".oni")
+    const oniDir = findUp.sync(".oni", { cwd: filePath })
 
     if (!oniDir) {
         return Q(DefaultConfiguration)
     }
 
-    return loadConfigurationFromFolder(path.join(oniDir, ".oni"))
+    return loadConfigurationFromFolder(oniDir)
 }
 
 function loadConfigurationFromFolder(folder: string): Q.Promise<IProjectConfiguration> {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "find-parent-dir": "0.3.0",
+    "find-up": "2.1.0",
     "lodash": "4.17.0",
     "minimist": "1.2.0",
     "neovim-client": "2.1.0",

--- a/vim/core/oni-plugin-tslint/lib/index.js
+++ b/vim/core/oni-plugin-tslint/lib/index.js
@@ -3,7 +3,7 @@ const path = require("path")
 const os = require("os")
 const exec = require("child_process").exec
 
-const findParentDir = require("find-parent-dir")
+const findUp = require("find-up")
 
 const tslintPath = path.join(__dirname, "..", "..", "..", "..", "node_modules", "tslint", "lib", "tslint-cli.js")
 
@@ -53,11 +53,11 @@ const activate = (Oni) => {
             return
         }
 
-        const project = findParentDir.sync(currentWorkingDirectory, "tsconfig.json")
+        const project = findUp.sync("tsconfig.json", { cwd: currentWorkingDirectory })
         let processArgs = []
 
         if (project) {
-            processArgs.push("--project", path.join(project, "tsconfig.json"))
+            processArgs.push("--project", project)
         } else {
             processArgs.push(arg.bufferFullPath)
         }
@@ -97,7 +97,7 @@ const activate = (Oni) => {
 
         processArgs = processArgs.concat(["--force", "--format", "json"])
 
-        processArgs = processArgs.concat(["--config", path.join(configPath, "tslint.json")])
+        processArgs = processArgs.concat(["--config", configPath])
         processArgs = processArgs.concat(args)
 
         return Q.nfcall(Oni.execNodeScript, tslintPath, processArgs, { cwd: workingDirectory })
@@ -139,7 +139,7 @@ const activate = (Oni) => {
     }
 
     function getLintConfig(workingDirectory) {
-        return findParentDir.sync(workingDirectory, "tslint.json")
+        return findUp.sync("tslint.json", { cwd: workingDirectory })
     }
 }
 

--- a/vim/core/oni-plugin-tslint/lib/index.js
+++ b/vim/core/oni-plugin-tslint/lib/index.js
@@ -59,9 +59,8 @@ const activate = (Oni) => {
                 }
                 tslint = filepath
             })
-            .then(() => {
-                let project = findUp.sync("tsconfig.json", { cwd: currentWorkingDirectory })
-
+            .then(() => findUp.sync("tsconfig.json", { cwd: currentWorkingDirectory }))
+            .then((project) => {
                 let processArgs = []
                 if (project) {
                     processArgs.push("--project", project)

--- a/vim/core/oni-plugin-typescript/src/LiveEvaluation.ts
+++ b/vim/core/oni-plugin-typescript/src/LiveEvaluation.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 
 import * as _ from "lodash"
 
-const findParentDir = require("find-parent-dir") // tslint:disable-line no-var-requires
+const findUp = require("find-up") // tslint:disable-line no-var-requires
 
 declare var Oni
 
@@ -53,10 +53,10 @@ export const evaluateBlock = (id: string, fileName: string, code: string) => {
                 const path = require("path")
                 // See if this is a 'node_modules' dependency:
 
-                const modulePath = findParentDir.sync(__dirname, path.join("node_modules", requirePath))
+                const modulePath = findUp.sync(path.join("node_modules", requirePath), { cwd: __dirname })
 
                 if (modulePath) {
-                    requirePath = path.join(modulePath, "node_modules", requirePath)
+                    requirePath = modulePath
                 }
 
                 return mod.require(requirePath)


### PR DESCRIPTION
`find-parent-dir` has a dependency on a deprecated call (https://github.com/thlorenz/find-parent-dir/issues/4) so I decided to replace it with [find-up](https://github.com/sindresorhus/find-up), which does basically the same thing but has support for Promises.  Also, `find-up` returns the full path of the filename rather than the parent dir.  This reduced some code since every usage of `find-parent-dir` was `join`ing the directory name and filename.

Now, with that said, I don't know anything about Promises.  I tried to emulate the Promise code found elsewhere in Oni but it's very likely I made a rookie mistake.  Please take a look and let me know if you have any suggestions.