### PR TITLE
Fix #122: Force BufEnter and buffer update events on connection

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -177,7 +177,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
                     // set title after attaching listeners so we can get the initial title
                     this.command("set title")
-                    this.callFunction("OniApiInfo", [])
+                    this.callFunction("OniConnect", [])
                 })
             }, (err) => {
                 this.emit("error", err)

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -116,6 +116,17 @@ function OniUpdateWindowDisplayMap()
     call OniNotify(["window_display_update", context, mapping])
 endfunction
 
+function OniConnect()
+    call OniApiInfo()
+
+    " Force BufEnter and buffer update events to be dispatched on connection
+    " Otherwise, there can be race conditions where the buffer is loaded
+    " prior to the UI attaching. See #122
+    call OniNotifyEvent("BufEnter")
+    call OniNotifyBufferUpdate()
+endfunction
+
+
 function OniApiInfo()
     if (has_key(api_info(),'version'))
         call OniNotify(["api_info",api_info()["version"]])


### PR DESCRIPTION
Fix #122 

There was a race condition where sometimes the BufferEnter / buffer update events were before triggered prior to connection, which caused the language service integration not to load until the file is modified.
