### PR TITLE
Fix #407, use editor.quickOpen.execCommand to filter files in quickOpen

### DIFF
--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -52,7 +52,7 @@ export class QuickOpen {
         if (overriddenCommand) {
             try {
                 // replace placeholder ${search} with "" for initial case
-                const files = execSync(overriddenCommand.replace("${search}", '""'), { cwd: process.cwd() })
+                const files = execSync(overriddenCommand.replace("${search}", ""), { cwd: process.cwd() })
                     .toString("utf8")
                     .split("\n")
                 this._showMenuFromFiles(files)

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -6,6 +6,7 @@
 
 import { execSync } from "child_process"
 import * as path from "path"
+import * as Log from "./../Log"
 
 import * as glob from "glob"
 import * as _ from "lodash"
@@ -37,7 +38,7 @@ export class QuickOpen {
 
     public show(): void {
         const config = Config.instance()
-        const overrriddenCommand = config.getValue("editor.quickOpen.execCommand")
+        const overriddenCommand = config.getValue("editor.quickOpen.execCommand")
         const exclude = config.getValue("oni.exclude")
 
         UI.Actions.showPopupMenu("quickOpen", [{
@@ -48,12 +49,17 @@ export class QuickOpen {
         }])
 
         // Overridden strategy
-        if (overrriddenCommand) {
-            const files = execSync(overrriddenCommand)
-                .toString("utf8")
-                .split("\n")
-            this._showMenuFromFiles(files)
-            return
+        if (overriddenCommand) {
+            try {
+                // replace placeholder ${search} with "" for initial case
+                const files = execSync(overriddenCommand.replace("${search}", '""'), { cwd: process.cwd() })
+                    .toString("utf8")
+                    .split("\n")
+                this._showMenuFromFiles(files)
+                return
+            } catch (e) {
+                Log.warn(`'${overriddenCommand}' returned an error: ${e.message}\nUsing default file list`)
+            }
         }
 
         // Default strategy

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -185,27 +185,33 @@ export function popupMenuReducer (s: State.IMenu | null, a: Actions.SimpleAction
 
 export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: string, id: string): State.IMenuOptionWithHighlights[] {
 
-    const config = Config.instance()
-    const overrriddenCommand = config.getValue("editor.quickOpen.execCommand")
     // if filtering files (not tasks) and overriddenCommand defined
-    if (id === "quickOpen" && overrriddenCommand) {
-        const files = execSync(overrriddenCommand.replace("${search}", searchString), { cwd: process.cwd() })
-            .toString("utf8")
-            .split("\n")
-        const opt: State.IMenuOptionWithHighlights[]  = files.map((untrimmedFile) => {
-            const f = untrimmedFile.trim()
-            const file = path.basename(f)
-            const folder = path.dirname(f)
-            return {
-                icon: "file-text-o",
-                label: file,
-                detail: folder,
-                pinned: false,
-                detailHighlights: [],
-                labelHighlights: [],
+    if (id === "quickOpen") {
+        const config = Config.instance()
+        const overriddenCommand = config.getValue("editor.quickOpen.execCommand")
+        if (overriddenCommand) {
+            try {
+                const files = execSync(overriddenCommand.replace("${search}", searchString), { cwd: process.cwd() })
+                    .toString("utf8")
+                    .split("\n")
+                const opt: State.IMenuOptionWithHighlights[]  = files.map((untrimmedFile) => {
+                    const f = untrimmedFile.trim()
+                    const file = path.basename(f)
+                    const folder = path.dirname(f)
+                    return {
+                        icon: "file-text-o",
+                        label: file,
+                        detail: folder,
+                        pinned: false,
+                        detailHighlights: [],
+                        labelHighlights: [],
+                    }
+                })
+                return opt
+            } catch (e) {
+                console.warn(`'${overriddenCommand}' returned an error: ${e.message}\nUsing default filtering`)
             }
-        })
-        return opt
+        }
     }
 
     if (!searchString) {

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -1,3 +1,5 @@
+import { execSync } from "child_process"
+import * as path from "path"
 import * as State from "./State"
 
 import * as Fuse from "fuse.js"
@@ -170,7 +172,7 @@ export function popupMenuReducer (s: State.IMenu | null, a: Actions.SimpleAction
             // If we already had search results, and this search is a superset of the previous,
             // just filter the already-pruned subset
             const optionsToSearch = a.payload.filter.indexOf(s.filter) === 0 ? s.filteredOptions : s.options
-            const filteredOptionsSorted = filterMenuOptions(optionsToSearch, a.payload.filter)
+            const filteredOptionsSorted = filterMenuOptions(optionsToSearch, a.payload.filter, s.id)
 
             return Object.assign({}, s, {
                 filter: a.payload.filter,
@@ -181,7 +183,30 @@ export function popupMenuReducer (s: State.IMenu | null, a: Actions.SimpleAction
     }
 }
 
-export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: string): State.IMenuOptionWithHighlights[] {
+export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: string, id: string): State.IMenuOptionWithHighlights[] {
+
+    const config = Config.instance()
+    const overrriddenCommand = config.getValue("editor.quickOpen.execCommand")
+    // if filtering files (not tasks) and overriddenCommand defined
+    if (id === "quickOpen" && overrriddenCommand) {
+        const files = execSync(overrriddenCommand.replace("${search}", searchString), { cwd: process.cwd() })
+            .toString("utf8")
+            .split("\n")
+        const opt: State.IMenuOptionWithHighlights[]  = files.map((untrimmedFile) => {
+            const f = untrimmedFile.trim()
+            const file = path.basename(f)
+            const folder = path.dirname(f)
+            return {
+                icon: "file-text-o",
+                label: file,
+                detail: folder,
+                pinned: false,
+                detailHighlights: [],
+                labelHighlights: [],
+            }
+        })
+        return opt
+    }
 
     if (!searchString) {
         const opt = options.map((o) => {


### PR DESCRIPTION
This pull requests changes the format of `editor.quickOpen.execCommand` to require a `${search}` variable to be defined.  That variable is used when filtering the files in Quick-Open.  The code seems right to me but my use of `execSync` always throws an error and I don't know why.  It's acting like `fzf` is exiting with a code of `1` but I don't see how.

So this code isn't functioning yet, I just wanted to create the pull request so I had a place to complain because I don't understand why it's failing.