### PR TITLE
Fix master build break

### DIFF
--- a/browser/test/Renderer/DOMRendererTests.ts
+++ b/browser/test/Renderer/DOMRendererTests.ts
@@ -23,7 +23,7 @@ describe("DOMRenderer", () => {
         beforeEach(() => {
             deltaRegionTracker = new IncrementalDeltaRegionTracker()
             screen = new NeovimScreen(deltaRegionTracker)
-            document = jsdom.jsdom("")
+            document = new jsdom.JSDOM("").window.document
 
             editorElement = document.createElement("div")
             elementFactory = new TestElementFactory(editorElement, document)

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "concurrently": "3.1.0",
     "cross-env": "3.1.3",
     "css-loader": "0.26.1",
-    "electron": "1.6.10",
+    "electron": "1.6.11",
     "electron-builder": "16.4.2",
     "electron-devtools-installer": "2.1.0",
     "extract-zip": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@types/jsdom": "11.0.0",
     "find-up": "2.1.0",
     "lodash": "4.17.0",
     "minimist": "1.2.0",
@@ -105,7 +104,7 @@
   "devDependencies": {
     "@types/classnames": "0.0.32",
     "@types/glob": "5.0.30",
-    "@types/jsdom": "2.0.29",
+    "@types/jsdom": "11.0.0",
     "@types/lodash": "4.14.38",
     "@types/minimist": "1.1.29",
     "@types/mkdirp": "0.3.29",
@@ -128,7 +127,7 @@
     "fuse.js": "2.6.2",
     "glob": "7.1.1",
     "innosetup-compiler": "5.5.9",
-    "jsdom": "9.9.1",
+    "jsdom": "11.0.0",
     "less": "2.7.1",
     "less-loader": "2.2.3",
     "less-plugin-autoprefix": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@types/jsdom": "11.0.0",
     "find-up": "2.1.0",
     "lodash": "4.17.0",
     "minimist": "1.2.0",


### PR DESCRIPTION
Looks like there was an issue with the `@types/jquery` dependency from `@types/jsdom`. Grabbing the latest `@types/jsdom` seems to have resolved it.