### PR TITLE
Fix #492: Add the `editor.scrollBar.visible` setting to control visibility of buffer scrollbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ A few interesting configuration options to set:
 - `editor.fontLigatures` - (default: `true`). If true, ligatures are enabled.
 - `editor.backgroundImageUrl` - specific a custom background image
 - `editor.backgroundImageSize` - specific a custom background size (cover, contain)
+- `editor.scrollBar.visible` - (default: `true`) sets whether the buffer scrollbar is visible
 
 See the `Config.ts` file for other interesting values to set.
 

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -66,6 +66,9 @@ export interface IConfigValues {
     "editor.fontSize": string
     "editor.fontFamily": string // Platform specific
 
+    // If true (default), the buffer scroll bar will be visible
+    "editor.scrollBar.visible": boolean
+
     // Command to list files for 'quick open'
     // For example, to use 'ag': ag --nocolor -l .
     //
@@ -123,6 +126,8 @@ export class Config extends EventEmitter {
         "editor.fontFamily": "",
 
         "editor.quickOpen.execCommand": null,
+
+        "editor.scrollBar.visible": true,
 
         "editor.fullScreenOnStart" : false,
 

--- a/browser/src/UI/Overlay/ScrollBarOverlay.ts
+++ b/browser/src/UI/Overlay/ScrollBarOverlay.ts
@@ -26,19 +26,6 @@ export class ScrollBarOverlay implements IOverlay {
 
     private _fileToMarkers: IFileToAllMarkers = {}
 
-    private _lastVisible: boolean = true
-    private _visible: boolean = true
-
-    public show(): void {
-        this._visible = true
-        this._updateScrollBar()
-    }
-
-    public hide(): void {
-        this._visible = false
-        this._updateScrollBar()
-    }
-
     public onBufferUpdate(_eventContext: Oni.EventContext, lines: string[]): void {
         this._currentFileLength = lines.length
     }
@@ -86,11 +73,6 @@ export class ScrollBarOverlay implements IOverlay {
         if (!this._element) {
             return
         }
-
-        if (this._lastVisible !== this._visible) {
-            
-        }
-
 
         if (!this._lastEvent) {
             return

--- a/browser/src/UI/Overlay/ScrollBarOverlay.ts
+++ b/browser/src/UI/Overlay/ScrollBarOverlay.ts
@@ -106,7 +106,6 @@ export class ScrollBarOverlay implements IOverlay {
             bufferSize: this._lastEvent.bufferTotalLines,
             windowTopLine: this._lastEvent.windowTopLine,
             windowBottomLine: this._lastEvent.windowBottomLine,
-            visible: false,
         }, this._element)
     }
 }

--- a/browser/src/UI/Overlay/ScrollBarOverlay.ts
+++ b/browser/src/UI/Overlay/ScrollBarOverlay.ts
@@ -26,6 +26,19 @@ export class ScrollBarOverlay implements IOverlay {
 
     private _fileToMarkers: IFileToAllMarkers = {}
 
+    private _lastVisible: boolean = true
+    private _visible: boolean = true
+
+    public show(): void {
+        this._visible = true
+        this._updateScrollBar()
+    }
+
+    public hide(): void {
+        this._visible = false
+        this._updateScrollBar()
+    }
+
     public onBufferUpdate(_eventContext: Oni.EventContext, lines: string[]): void {
         this._currentFileLength = lines.length
     }
@@ -74,6 +87,11 @@ export class ScrollBarOverlay implements IOverlay {
             return
         }
 
+        if (this._lastVisible !== this._visible) {
+            
+        }
+
+
         if (!this._lastEvent) {
             return
         }
@@ -88,6 +106,7 @@ export class ScrollBarOverlay implements IOverlay {
             bufferSize: this._lastEvent.bufferTotalLines,
             windowTopLine: this._lastEvent.windowTopLine,
             windowBottomLine: this._lastEvent.windowBottomLine,
+            visible: false,
         }, this._element)
     }
 }

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
-// import { connect, Provider } from "react-redux"
-
-// import { store } from "./../index"
+import { connect, Provider } from "react-redux"
+import { store } from "./../index"
+import * as State from "./../State"
 
 require("./BufferScrollBar.less") // tslint:disable-line no-var-requires
 
@@ -67,6 +67,27 @@ export class BufferScrollBar extends React.Component<IBufferScrollBarProps, void
     }
 }
 
-export function renderBufferScrollBar(props: IBufferScrollBarProps, element: HTMLElement) {
-    ReactDOM.render(<BufferScrollBar {...props} />, element)
+export interface IRenderBufferScrollBarArgs {
+    bufferSize: number
+    height: number
+    windowTopLine: number
+    windowBottomLine: number
+    markers: IScrollBarMarker[]
+}
+
+const mapStateToProps = (state: State.IState, inProps: IRenderBufferScrollBarArgs): IBufferScrollBarProps => {
+    const visible = state.configuration["editor.scrollBar.visible"]
+
+    return {
+        ...inProps,
+        visible
+    }
+}
+
+const ConnectedBufferScrollBar = connect(mapStateToProps)(BufferScrollBar)
+
+export function renderBufferScrollBar(props: IRenderBufferScrollBarArgs, element: HTMLElement) {
+    ReactDOM.render(<Provider store={store}>
+                        <ConnectedBufferScrollBar {...props} />
+                    </Provider>, element)
 }

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -80,7 +80,7 @@ const mapStateToProps = (state: State.IState, inProps: IRenderBufferScrollBarArg
 
     return {
         ...inProps,
-        visible
+        visible,
     }
 }
 

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
-import { connect, Provider } from "react-redux"
+// import { connect, Provider } from "react-redux"
 
-import { store } from "./../index"
+// import { store } from "./../index"
 
 require("./BufferScrollBar.less") // tslint:disable-line no-var-requires
 
@@ -66,8 +66,6 @@ export class BufferScrollBar extends React.Component<IBufferScrollBarProps, void
             </div>
     }
 }
-
-export class Connected
 
 export function renderBufferScrollBar(props: IBufferScrollBarProps, element: HTMLElement) {
     ReactDOM.render(<BufferScrollBar {...props} />, element)

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -22,7 +22,7 @@ export interface IScrollBarMarker {
     color: string
 }
 
-export class BufferScrollBar extends React.Component<IBufferScrollBarProps, void> {
+export class BufferScrollBar extends React.PureComponent<IBufferScrollBarProps, void> {
 
     constructor(props: any) {
         super(props)

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -1,6 +1,10 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
+import { connect, Provider } from "react-redux"
+
+import { store } from "./../index"
+
 require("./BufferScrollBar.less") // tslint:disable-line no-var-requires
 
 export interface IBufferScrollBarProps {
@@ -9,6 +13,7 @@ export interface IBufferScrollBarProps {
     windowTopLine: number
     windowBottomLine: number
     markers: IScrollBarMarker[]
+    visible: boolean
 }
 
 export interface IScrollBarMarker {
@@ -24,6 +29,11 @@ export class BufferScrollBar extends React.Component<IBufferScrollBarProps, void
     }
 
     public render(): JSX.Element {
+
+        if (!this.props.visible) {
+            return null
+        }
+
         const windowHeight = ((this.props.windowBottomLine - this.props.windowTopLine + 1) / this.props.bufferSize) * this.props.height
         const windowTop = ((this.props.windowTopLine - 1) / this.props.bufferSize) * this.props.height
 
@@ -56,6 +66,8 @@ export class BufferScrollBar extends React.Component<IBufferScrollBarProps, void
             </div>
     }
 }
+
+export class Connected
 
 export function renderBufferScrollBar(props: IBufferScrollBarProps, element: HTMLElement) {
     ReactDOM.render(<BufferScrollBar {...props} />, element)

--- a/vim/core/oni-plugin-typescript/package.json
+++ b/vim/core/oni-plugin-typescript/package.json
@@ -18,11 +18,11 @@
     "dependencies": {
     },
     "devDependencies": {
-        "@types/bluebird": "^3.0.35",
+        "@types/bluebird": "3.0.35",
         "@types/es6-promise": "0.0.32",
-        "@types/lodash": "^4.14.38",
-        "@types/mocha": "^2.2.33",
-        "@types/node": "^6.0.46",
-        "@types/sinon": "^1.16.32"
+        "@types/lodash": "4.14.38",
+        "@types/mocha": "2.2.33",
+        "@types/node": "6.0.46",
+        "@types/sinon": "1.16.32"
     }
 }


### PR DESCRIPTION
__Issue:__ There is no way to disable the buffer scroll bar, which some users may find distracting or unnecessary.

__Fix:__ Add a setting for `editor.scrollBar.visible` that can be modified in the `config.js`:

![scrollbar setting](https://user-images.githubusercontent.com/13532591/27390902-54e36a12-5657-11e7-8a4e-bc1508bc421c.gif)

