### PR TITLE
Fix #495: Clean up list jumpiness in autocompletion menu

### DIFF
--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -15,9 +15,7 @@ export class Mouse extends EventEmitter {
         this._editorElement = editorElement
         this._screen = screen
 
-
         // MUSTFIX: Temporary hack to remove mouse handling to prototype completion handler.
-
         document.body.addEventListener("mousedown1", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 

--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -15,14 +15,15 @@ export class Mouse extends EventEmitter {
         this._editorElement = editorElement
         this._screen = screen
 
-        document.body.addEventListener("mousedown", (evt: MouseEvent) => {
+
+        document.body.addEventListener("mousedown1", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 
             this.emit("mouse", `<LeftMouse><${line},${column}>`)
             this._isDragging = true
         })
 
-        document.body.addEventListener("mousemove", (evt: MouseEvent) => {
+        document.body.addEventListener("mousemove1", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 
             if (this._isDragging) {
@@ -30,7 +31,7 @@ export class Mouse extends EventEmitter {
             }
         })
 
-        document.body.addEventListener("mouseup", (evt: MouseEvent) => {
+        document.body.addEventListener("mouseup1", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 
             this.emit("mouse", `<LeftRelease><${line},${column}>`)
@@ -38,7 +39,7 @@ export class Mouse extends EventEmitter {
         })
 
         // The internet told me 'mousewheel' is deprecated and use this.
-        document.body.addEventListener("wheel", (evt: WheelEvent) => {
+        document.body.addEventListener("wheel1", (evt: WheelEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
             let scrollcmdY = `<`
             let scrollcmdX = `<`

--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -16,6 +16,8 @@ export class Mouse extends EventEmitter {
         this._screen = screen
 
 
+        // MUSTFIX: Temporary hack to remove mouse handling to prototype completion handler.
+
         document.body.addEventListener("mousedown1", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -6,8 +6,7 @@
     background-color: @background-color;
     color: @text-color;
     max-width: 800px;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden;
     animation-name: appear;
     animation-duration: 0.1s;
 
@@ -80,6 +79,8 @@
         .box-shadow-inset;
         padding: 8px;
         font-size: 10px;
+        max-height: 48px;
+        overflow-y: auto;
         color: @text-color-dark;
     }
 }

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -6,7 +6,6 @@
     background-color: @background-color;
     color: @text-color;
     max-width: 800px;
-    max-height: 300px;
     overflow-x: hidden;
     overflow-y: auto;
     animation-name: appear;
@@ -75,11 +74,13 @@
             font-size: 11px;
             visibility: hidden;
         }
+    }
 
-        .documentation {
-            font-size: 10px;
-            color: @text-color-highlight;
-        }
+    .documentation {
+        .box-shadow-inset;
+        padding: 8px;
+        font-size: 10px;
+        color: @text-color-dark;
     }
 }
 

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -1,6 +1,9 @@
 @import (reference) "./common.less";
 
 .autocompletion {
+    /* Promote to a layer, to improve paint performance when autocomplete is open */
+    .layer;
+
     .box-shadow;
 
     background-color: @background-color;

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -5,7 +5,7 @@
 
     background-color: @background-color;
     color: @text-color;
-    max-width: 800px;
+    width: 600px;
     overflow: hidden;
     animation-name: appear;
     animation-duration: 0.1s;

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -56,7 +56,6 @@
 
             .highlight {
                 font-weight: bold;
-                font-style: italic;
                 color: @text-color-highlight;
             }
         }

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -55,10 +55,27 @@ export class AutoCompletion extends React.Component<IAutoCompletionProps, void> 
             return <AutoCompletionItem {...s} isSelected={isSelected} base={this.props.base} />
         })
 
+        const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
+
         return (<div style={containerStyle} className="autocompletion">
-            {entries}
+            <div className="entries">
+                {entries}
+            </div>
+            <AutoCompletionDocumentation documentation={selectedItemDocumentation} />
         </div>)
     }
+}
+
+const getDocumentationFromItems = (items: Oni.Plugin.CompletionInfo[], selectedIndex: number): string => {
+    if (!items || !items.length) {
+        return null
+    }
+
+    if (selectedIndex >= items.length) {
+        return null
+    }
+
+    return items[selectedIndex].documentation
 }
 
 export interface IAutoCompletionItemProps extends Oni.Plugin.CompletionInfo {
@@ -74,8 +91,6 @@ export class AutoCompletionItem extends React.Component<IAutoCompletionItemProps
             className += " selected"
         }
 
-        const documentation = this.props.isSelected ? this.props.documentation : ""
-
         const highlightColor = this.props.highlightColor || this._getDefaultHighlightColor(this.props.kind as any) // FIXME: undefined
 
         const iconContainerStyle = {
@@ -90,7 +105,6 @@ export class AutoCompletionItem extends React.Component<IAutoCompletionItemProps
                 <HighlightText className="label" highlightClassName="highlight" highlightText={this.props.base} text={this.props.label} />
                 <span className="detail">{this.props.detail}</span>
             </div>
-            <div className="documentation">{documentation}</div>
         </div>
     }
 
@@ -98,6 +112,20 @@ export class AutoCompletionItem extends React.Component<IAutoCompletionItemProps
         // TODO: Extend this logic for better defaults per kind
         return "rgb(0, 255, 100)"
     }
+}
+
+export interface IAutoCompletionDocumentationProps {
+    documentation: string
+}
+
+export const AutoCompletionDocumentation = (props: IAutoCompletionDocumentationProps) => {
+    const { documentation } = props
+
+    if (!documentation) {
+        return null
+    }
+
+    return <div className="documentation">{documentation}</div>
 }
 
 export interface IAutoCompletionIconProps {

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -57,7 +57,7 @@ export class AutoCompletion extends React.Component<IAutoCompletionProps, void> 
 
         const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
 
-        return (<div style={containerStyle} className="autocompletion" onMouseDown={(evt)=>this._preventDefault(evt)} onMouseUp={(evt)=>this._preventDefault(evt)}>
+        return (<div style={containerStyle} className="autocompletion" onMouseDown={(evt) => this._preventDefault(evt)} onMouseUp={(evt) => this._preventDefault(evt)}>
             <div className="entries">
                 {entries}
             </div>

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -57,17 +57,12 @@ export class AutoCompletion extends React.Component<IAutoCompletionProps, void> 
 
         const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
 
-        return (<div style={containerStyle} className="autocompletion" onMouseDown={(evt) => this._preventDefault(evt)} onMouseUp={(evt) => this._preventDefault(evt)}>
+        return (<div style={containerStyle} className="autocompletion enable-mouse">
             <div className="entries">
                 {entries}
             </div>
             <AutoCompletionDocumentation documentation={selectedItemDocumentation} />
         </div>)
-    }
-
-    private _preventDefault(evt: React.MouseEvent<HTMLElement>) {
-        evt.preventDefault()
-        evt.stopPropagation()
     }
 }
 

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -57,12 +57,17 @@ export class AutoCompletion extends React.Component<IAutoCompletionProps, void> 
 
         const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
 
-        return (<div style={containerStyle} className="autocompletion">
+        return (<div style={containerStyle} className="autocompletion" onMouseDown={(evt)=>this._preventDefault(evt)} onMouseUp={(evt)=>this._preventDefault(evt)}>
             <div className="entries">
                 {entries}
             </div>
             <AutoCompletionDocumentation documentation={selectedItemDocumentation} />
         </div>)
+    }
+
+    private _preventDefault(evt: React.MouseEvent<HTMLElement>) {
+        evt.preventDefault()
+        evt.stopPropagation()
     }
 }
 

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -65,7 +65,6 @@
                 .highlight {
                     color: @text-color-highlight;
                     font-weight: bold;
-                    font-style: italic;
                 }
             }
 
@@ -77,9 +76,7 @@
                 .highlight {
                     color: @text-color-highlight;
                     font-weight: bold;
-                    font-style: italic;
                 }
-
             }
         }
     }

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -22,7 +22,7 @@
 
         .documentation {
             margin: 4px;
-            color: @text-color-highlight;
+            color: @text-color-detail;
             font-size: @font-size-small;
         }
 

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -5,7 +5,8 @@
 
 // Colors
 @text-color: rgb(200, 200, 200);
-@text-color-highlight: rgb(50, 200, 255);
+@text-color-dark: rgb(150, 150, 150);
+@text-color-highlight: rgb(240, 240, 240);
 @text-color-detail: rgb(100, 100, 100);
 
 @text-color-info: #6494ed;
@@ -30,6 +31,26 @@
     left: 0px;
     right: 0px;
     bottom: 0px;
+}
+
+::-webkit-scrollbar-track
+{
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+  border-radius: 10px;
+  background-color: rgb(100, 100, 100);
+}
+
+::-webkit-scrollbar
+{
+  width: 12px;
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar-thumb
+{
+  border-radius: 10px;
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,1);
+ background-color: rgb(150, 150, 150)
 }
 
 /* Layer is used to force webkit to promote the element to an individual layer.
@@ -63,4 +84,8 @@
 
 .box-shadow-up {
   box-shadow: 0 -8px 20px 0 rgba(0, 0, 0, 0.2);
+}
+
+.box-shadow-inset {
+  box-shadow: inset 0 4px 8px 2px rgba(0, 0, 0, 0.2)
 }

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -35,22 +35,20 @@
 
 ::-webkit-scrollbar-track
 {
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-  border-radius: 10px;
-  background-color: rgb(100, 100, 100);
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    background-color: @background-color;
 }
 
 ::-webkit-scrollbar
 {
-  width: 12px;
-  background-color: #F5F5F5;
+    width: 12px;
+    background-color: rgb(0, 0, 0);
 }
 
 ::-webkit-scrollbar-thumb
 {
-  border-radius: 10px;
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,1);
- background-color: rgb(150, 150, 150)
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    background-color: @background-color-lighter;
 }
 
 /* Layer is used to force webkit to promote the element to an individual layer.


### PR DESCRIPTION
__Issue:__ The autocompletion list is jumpy, so it is a jarring experience for users when the list item changes.

__Fix:__ Move the details to the bottom of the completion menu. I also address another jumping issue - sometimes the autocompletion menu would expand/collapse, which was also a jarring experience. In addition, I made the highlighting a bit more subtle, and added an overflow experience for the details:

![completion-v2](https://user-images.githubusercontent.com/13532591/27496290-4d5c347c-580a-11e7-8107-de1704886ff7.gif)