### PR TITLE
Refactor: Extract out NeovimEditor functionality to NeovimSurface

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,4 +1,3 @@
-- Refactor surface out
 - Move cursor/cursorline/cursorrow to surface
 - Fix pointer events by defaulting stack to `pointer-events: none`
 - Mouse-enabled elements will need to specify .enable-mouse (`pointer-events: auto`)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,4 @@
+- Refactor surface out
+- Move cursor/cursorline/cursorrow to surface
+- Fix pointer events by defaulting stack to `pointer-events: none`
+- Mouse-enabled elements will need to specify .enable-mouse (`pointer-events: auto`)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,0 @@
-- Move cursor/cursorline/cursorrow to surface
-- Fix pointer events by defaulting stack to `pointer-events: none`
-- Mouse-enabled elements will need to specify .enable-mouse (`pointer-events: auto`)

--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -7,5 +7,5 @@ export interface IEditor {
 
     init(filesToOpen: string[]): void
 
-    render(element: HTMLDivElement): void
+    render(): JSX.Element
 }

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -49,6 +49,25 @@ import { InstallHelp } from "./../UI/components/InstallHelp"
 import { NeovimInput } from "./NeovimInput"
 import { NeovimRenderer } from "./NeovimRenderer"
 
+export interface INeovimSurfaceProps {
+    neovimInstance: NeovimInstance
+    deltaRegionTracker: IncrementalDeltaRegionTracker
+    renderer: DOMRenderer
+    screen: NeovimScreen
+}
+
+export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, void> {
+    public render(): JSX.Element {
+        return <div className="editor">
+            <NeovimRenderer renderer={this.props.renderer}
+                neovimInstance={this.props.neovimInstance}
+                deltaRegionTracker={this.props.deltaRegionTracker} />
+            <NeovimInput neovimInstance={this.props.neovimInstance}
+                screen={this.props.screen} />
+        </div>
+    }
+}
+
 export class NeovimEditor implements IEditor {
 
     private _neovimInstance: NeovimInstance
@@ -309,14 +328,10 @@ export class NeovimEditor implements IEditor {
     }
 
     public render(): JSX.Element {
-
-        return <div className="editor">
-            <NeovimRenderer renderer={this._renderer}
+        return <NeovimSurface renderer={this._renderer}
                 neovimInstance={this._neovimInstance}
-                deltaRegionTracker={this._deltaRegionManager} />
-            <NeovimInput neovimInstance={this._neovimInstance}
+                deltaRegionTracker={this._deltaRegionManager}
                 screen={this._screen} />
-        </div>
     }
 
     private _onModeChanged(newMode: string): void {

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -46,27 +46,7 @@ import { IEditor } from "./Editor"
 
 import { InstallHelp } from "./../UI/components/InstallHelp"
 
-import { NeovimInput } from "./NeovimInput"
-import { NeovimRenderer } from "./NeovimRenderer"
-
-export interface INeovimSurfaceProps {
-    neovimInstance: NeovimInstance
-    deltaRegionTracker: IncrementalDeltaRegionTracker
-    renderer: DOMRenderer
-    screen: NeovimScreen
-}
-
-export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, void> {
-    public render(): JSX.Element {
-        return <div className="editor">
-            <NeovimRenderer renderer={this.props.renderer}
-                neovimInstance={this.props.neovimInstance}
-                deltaRegionTracker={this.props.deltaRegionTracker} />
-            <NeovimInput neovimInstance={this.props.neovimInstance}
-                screen={this.props.screen} />
-        </div>
-    }
-}
+import { NeovimSurface } from "./NeovimSurface"
 
 export class NeovimEditor implements IEditor {
 

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -375,9 +375,6 @@ export class NeovimEditor implements IEditor {
         this._cursorLine = this._config.getValue("editor.cursorLine")
         this._cursorColumn = this._config.getValue("editor.cursorColumn")
 
-        UI.Actions.setCursorLineOpacity(this._config.getValue("editor.cursorLineOpacity"))
-        UI.Actions.setCursorColumnOpacity(this._config.getValue("editor.cursorColumnOpacity"))
-
         if (this._cursorLine) {
             UI.Actions.showCursorLine()
         }

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -57,9 +57,6 @@ export class NeovimEditor implements IEditor {
     private _pendingTimeout: any = null
     private _element: HTMLElement
 
-    private _cursorLine: boolean = false
-    private _cursorColumn: boolean = false
-
     // Services
     private _tasks: Tasks
 
@@ -318,25 +315,14 @@ export class NeovimEditor implements IEditor {
         UI.Actions.setMode(newMode)
 
         if (newMode === "normal") {
-            if (this._cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
-                UI.Actions.showCursorLine()
-            }
-            if (this._cursorColumn) {
-                UI.Actions.showCursorColumn()
-            }
+            UI.Actions.showCursorColumn()
             UI.Actions.hideCompletions()
             UI.Actions.hideSignatureHelp()
         } else if (newMode === "insert") {
             UI.Actions.hideQuickInfo()
-            if (this._cursorLine) { // TODO: Add "unhide" i.e. only show if previously visible
-                UI.Actions.showCursorLine()
-            }
-            if (this._cursorColumn) {
-                UI.Actions.showCursorColumn()
-            }
-        } else if (newMode === "cmdline") {
+            UI.Actions.showCursorColumn()
+        } else if (newMode.indexOf("cmdline") >= 0) {
             UI.Actions.hideCursorColumn() // TODO: cleaner way to hide and unhide?
-            UI.Actions.hideCursorLine()
             UI.Actions.hideCompletions()
             UI.Actions.hideQuickInfo()
         }
@@ -372,17 +358,6 @@ export class NeovimEditor implements IEditor {
     }
 
     private _onConfigChanged(): void {
-        this._cursorLine = this._config.getValue("editor.cursorLine")
-        this._cursorColumn = this._config.getValue("editor.cursorColumn")
-
-        if (this._cursorLine) {
-            UI.Actions.showCursorLine()
-        }
-
-        if (this._cursorColumn) {
-            UI.Actions.showCursorColumn()
-        }
-
         this._neovimInstance.setFont(this._config.getValue("editor.fontFamily"), this._config.getValue("editor.fontSize"))
         this._onUpdate()
     }

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -42,11 +42,30 @@ import { ScrollBarOverlay } from "./../UI/Overlay/ScrollBarOverlay"
 import { Rectangle } from "./../UI/Types"
 
 import { Keyboard } from "./../Input/Keyboard"
-import { Mouse } from "./../Input/Mouse"
+// import { Mouse } from "./../Input/Mouse"
 
 import { IEditor } from "./Editor"
 
 import { InstallHelp } from "./../UI/components/InstallHelp"
+
+export interface INeovimRendererProps {
+    renderer: DOMRenderer
+}
+
+export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, void> {
+
+    private _element: HTMLDivElement
+
+    public componentDidMount(): void {
+        if (this._element) {
+            this.props.renderer.start(this._element)
+        }
+    }
+
+    public render(): JSX.Element {
+        return <div ref={ (elem) => this._element = elem } className="editor"></div>
+    }
+}
 
 export class NeovimEditor implements IEditor {
 
@@ -309,18 +328,18 @@ export class NeovimEditor implements IEditor {
         this._neovimInstance.start(filesToOpen)
     }
 
-    public render(element: HTMLDivElement): void {
-        this._element = element
-        this._renderer.start(element)
+    public render(): JSX.Element {
 
         this._onResize()
 
-        const mouse = new Mouse(element, this._screen)
+        // const mouse = new Mouse(element, this._screen)
 
-        mouse.on("mouse", (mouseInput: string) => {
-            UI.Actions.hideCompletions()
-            this._neovimInstance.input(mouseInput)
-        })
+        // mouse.on("mouse", (mouseInput: string) => {
+        //     UI.Actions.hideCompletions()
+        //     this._neovimInstance.input(mouseInput)
+        // })
+
+        return <NeovimRenderer renderer={this._renderer} />
     }
 
     private _onModeChanged(newMode: string): void {

--- a/browser/src/Editor/NeovimInput.tsx
+++ b/browser/src/Editor/NeovimInput.tsx
@@ -35,6 +35,6 @@ export class NeovimInput extends React.PureComponent<INeovimInputProps, void> {
     }
 
     public render(): JSX.Element {
-        return <div ref={ (elem) => this._element = elem } className="stack enable-mouse-events"></div>
+        return <div ref={ (elem) => this._element = elem } className="stack enable-mouse"></div>
     }
 }

--- a/browser/src/Editor/NeovimInput.tsx
+++ b/browser/src/Editor/NeovimInput.tsx
@@ -35,6 +35,6 @@ export class NeovimInput extends React.PureComponent<INeovimInputProps, void> {
     }
 
     public render(): JSX.Element {
-        return <div ref={ (elem) => this._element = elem } className="stack"></div>
+        return <div ref={ (elem) => this._element = elem } className="stack enable-mouse-events"></div>
     }
 }

--- a/browser/src/Editor/NeovimInput.tsx
+++ b/browser/src/Editor/NeovimInput.tsx
@@ -1,0 +1,40 @@
+/**
+ * NeovimInput.tsx
+ *
+ * Layer responsible for handling Neovim input interactiosn
+ */
+
+import * as React from "react"
+
+import { NeovimInstance } from "./../NeovimInstance"
+import { NeovimScreen } from "./../Screen"
+
+import * as UI from "./../UI/index"
+
+import { Keyboard } from "./../Input/Keyboard"
+import { Mouse } from "./../Input/Mouse"
+
+export interface INeovimInputProps {
+    neovimInstance: NeovimInstance
+    screen: NeovimScreen
+}
+
+export class NeovimInput extends React.PureComponent<INeovimInputProps, void> {
+    private _element: HTMLDivElement
+    private _mouse: Mouse
+
+    public componentDidMount(): void {
+        if (this._element) {
+            this._mouse = new Mouse(this._element, this.props.screen)
+
+            this._mouse.on("mouse", (mouseInput: string) => {
+                UI.Actions.hideCompletions()
+                this.props.neovimInstance.input(mouseInput)
+            })
+        }
+    }
+
+    public render(): JSX.Element {
+        return <div ref={ (elem) => this._element = elem } className="stack"></div>
+    }
+}

--- a/browser/src/Editor/NeovimInput.tsx
+++ b/browser/src/Editor/NeovimInput.tsx
@@ -11,7 +11,7 @@ import { NeovimScreen } from "./../Screen"
 
 import * as UI from "./../UI/index"
 
-import { Keyboard } from "./../Input/Keyboard"
+// import { Keyboard } from "./../Input/Keyboard"
 import { Mouse } from "./../Input/Mouse"
 
 export interface INeovimInputProps {

--- a/browser/src/Editor/NeovimRenderer.tsx
+++ b/browser/src/Editor/NeovimRenderer.tsx
@@ -44,7 +44,7 @@ export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, vo
     }
 
     public render(): JSX.Element {
-        return <div ref={ (elem) => this._element = elem } className="stack"></div>
+        return <div ref={ (elem) => this._element = elem } className="stack layer"></div>
     }
 
     private _onResize(): void {

--- a/browser/src/Editor/NeovimRenderer.tsx
+++ b/browser/src/Editor/NeovimRenderer.tsx
@@ -9,9 +9,6 @@ import * as React from "react"
 import { IncrementalDeltaRegionTracker } from "./../DeltaRegionTracker"
 import { NeovimInstance } from "./../NeovimInstance"
 import { DOMRenderer } from "./../Renderer/DOMRenderer"
-import { NeovimScreen } from "./../Screen"
-
-import * as UI from "./../UI/index"
 
 export interface INeovimRendererProps {
     neovimInstance: NeovimInstance

--- a/browser/src/Editor/NeovimRenderer.tsx
+++ b/browser/src/Editor/NeovimRenderer.tsx
@@ -1,0 +1,64 @@
+/**
+ * NeovimRenderer.tsx
+ *
+ * Layer responsible for invoking the INeovimRender strategy and applying to the DOM
+ */
+
+import * as React from "react"
+
+import { IncrementalDeltaRegionTracker } from "./../DeltaRegionTracker"
+import { NeovimInstance } from "./../NeovimInstance"
+import { DOMRenderer } from "./../Renderer/DOMRenderer"
+import { NeovimScreen } from "./../Screen"
+
+import * as UI from "./../UI/index"
+
+export interface INeovimRendererProps {
+    neovimInstance: NeovimInstance
+    deltaRegionTracker: IncrementalDeltaRegionTracker
+    renderer: DOMRenderer
+}
+
+export class NeovimRenderer extends React.PureComponent<INeovimRendererProps, void> {
+
+    private _element: HTMLDivElement
+    private _boundOnResizeMethod: any
+
+    public componentDidMount(): void {
+        if (this._element) {
+            this.props.renderer.start(this._element)
+
+            this._onResize()
+        }
+
+        if (!this._boundOnResizeMethod) {
+            this._boundOnResizeMethod = this._onResize.bind(this)
+            window.addEventListener("resize", this._boundOnResizeMethod)
+        }
+    }
+
+    public componentWillUnmount(): void {
+        // TODO: Stop renderer
+
+        if (this._boundOnResizeMethod) {
+            window.removeEventListener("resize", this._boundOnResizeMethod)
+            this._boundOnResizeMethod = null
+        }
+    }
+
+    public render(): JSX.Element {
+        return <div ref={ (elem) => this._element = elem } className="stack"></div>
+    }
+
+    private _onResize(): void {
+        if (!this._element) {
+            return
+        }
+
+        const width = this._element.offsetWidth
+        const height = this._element.offsetHeight
+
+        this.props.neovimInstance.resize(width, height)
+        this.props.renderer.onResize()
+    }
+}

--- a/browser/src/Editor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimSurface.tsx
@@ -1,0 +1,34 @@
+/**
+ * NeovimEditor.ts
+ *
+ * IEditor implementation for Neovim
+ */
+
+import * as React from "react"
+
+import { IncrementalDeltaRegionTracker } from "./../DeltaRegionTracker"
+import { NeovimInstance } from "./../NeovimInstance"
+import { DOMRenderer } from "./../Renderer/DOMRenderer"
+import { NeovimScreen } from "./../Screen"
+
+import { NeovimInput } from "./NeovimInput"
+import { NeovimRenderer } from "./NeovimRenderer"
+
+export interface INeovimSurfaceProps {
+    neovimInstance: NeovimInstance
+    deltaRegionTracker: IncrementalDeltaRegionTracker
+    renderer: DOMRenderer
+    screen: NeovimScreen
+}
+
+export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, void> {
+    public render(): JSX.Element {
+        return <div className="editor">
+            <NeovimRenderer renderer={this.props.renderer}
+                neovimInstance={this.props.neovimInstance}
+                deltaRegionTracker={this.props.deltaRegionTracker} />
+            <NeovimInput neovimInstance={this.props.neovimInstance}
+                screen={this.props.screen} />
+        </div>
+    }
+}

--- a/browser/src/Editor/NeovimSurface.tsx
+++ b/browser/src/Editor/NeovimSurface.tsx
@@ -11,6 +11,9 @@ import { NeovimInstance } from "./../NeovimInstance"
 import { DOMRenderer } from "./../Renderer/DOMRenderer"
 import { NeovimScreen } from "./../Screen"
 
+import { Cursor } from "./../UI/components/Cursor"
+import { CursorLine } from "./../UI/components/CursorLine"
+
 import { NeovimInput } from "./NeovimInput"
 import { NeovimRenderer } from "./NeovimRenderer"
 
@@ -27,6 +30,11 @@ export class NeovimSurface extends React.PureComponent<INeovimSurfaceProps, void
             <NeovimRenderer renderer={this.props.renderer}
                 neovimInstance={this.props.neovimInstance}
                 deltaRegionTracker={this.props.deltaRegionTracker} />
+            <div className="stack layer">
+                <Cursor />
+                <CursorLine lineType={"line"} />
+                <CursorLine lineType={"column"} />
+            </div>
             <NeovimInput neovimInstance={this.props.neovimInstance}
                 screen={this.props.screen} />
         </div>

--- a/browser/src/Input/Mouse.ts
+++ b/browser/src/Input/Mouse.ts
@@ -15,14 +15,14 @@ export class Mouse extends EventEmitter {
         this._editorElement = editorElement
         this._screen = screen
 
-        document.body.addEventListener("mousedown", (evt: MouseEvent) => {
+        this._editorElement.addEventListener("mousedown", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 
             this.emit("mouse", `<LeftMouse><${line},${column}>`)
             this._isDragging = true
         })
 
-        document.body.addEventListener("mousemove", (evt: MouseEvent) => {
+        this._editorElement.addEventListener("mousemove", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 
             if (this._isDragging) {
@@ -30,7 +30,7 @@ export class Mouse extends EventEmitter {
             }
         })
 
-        document.body.addEventListener("mouseup", (evt: MouseEvent) => {
+        this._editorElement.addEventListener("mouseup", (evt: MouseEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
 
             this.emit("mouse", `<LeftRelease><${line},${column}>`)
@@ -38,7 +38,7 @@ export class Mouse extends EventEmitter {
         })
 
         // The internet told me 'mousewheel' is deprecated and use this.
-        document.body.addEventListener("wheel", (evt: WheelEvent) => {
+        this._editorElement.addEventListener("wheel", (evt: WheelEvent) => {
             const { line, column } = this._convertEventToPosition(evt)
             let scrollcmdY = `<`
             let scrollcmdX = `<`

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -154,20 +154,6 @@ export interface IHideCursorColumnAction {
     type: "HIDE_CURSOR_COLUMN"
 }
 
-export interface ISetCursorLineOpacityAction {
-    type: "SET_CURSOR_LINE_OPACITY"
-    payload: {
-        opacity: number,
-    }
-}
-
-export interface ISetCursorColumnOpacityAction {
-    type: "SET_CURSOR_COLUMN_OPACITY"
-    payload: {
-        opacity: number,
-    }
-}
-
 export interface ISetConfigurationValue<K extends keyof Config.IConfigValues> {
     type: "SET_CONFIGURATION_VALUE"
     payload: {
@@ -222,8 +208,6 @@ export type SimpleAction =
     IHideCursorColumnAction |
     IShowCursorLineAction |
     IShowCursorColumnAction |
-    ISetCursorColumnOpacityAction |
-    ISetCursorLineOpacityAction |
     IToggleLogFold |
     IChangeLogsVisibility |
     IMakeLog

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -81,14 +81,6 @@ export function reducer<K extends keyof Config.IConfigValues> (s: State.IState, 
              return Object.assign({}, s, {
                  cursorColumnVisible: true,
             })
-        case "SET_CURSOR_LINE_OPACITY":
-            return Object.assign({}, s, {
-                cursorLineOpacity: a.payload.opacity,
-            })
-        case "SET_CURSOR_COLUMN_OPACITY":
-            return Object.assign({}, s, {
-                cursorLineOpacity: a.payload.opacity,
-            })
         case "SET_CONFIGURATION_VALUE":
             let obj: Partial<Config.IConfigValues> = {}
             obj[a.payload.key] = a.payload.value

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -17,7 +17,7 @@ interface IRootComponentProps {
 export class RootComponent extends React.Component<IRootComponentProps, void> {
     public render() {
 
-        return <div className="stack">
+        return <div className="stack disable-mouse-events">
             <div className="stack">
                 <Background />
             </div>

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -17,7 +17,7 @@ interface IRootComponentProps {
 export class RootComponent extends React.Component<IRootComponentProps, void> {
     public render() {
 
-        return <div className="stack disable-mouse-events">
+        return <div className="stack disable-mouse">
             <div className="stack">
                 <Background />
             </div>

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -2,8 +2,6 @@ import * as React from "react"
 
 import { AutoCompletionContainer } from "./components/AutoCompletion"
 import { Background } from "./components/Background"
-import { Cursor } from "./components/Cursor"
-import { CursorLine } from "./components/CursorLine"
 import { EditorHost } from "./components/EditorHost"
 import { Logs } from "./components/Logs"
 import { MenuContainer } from "./components/Menu"
@@ -26,13 +24,10 @@ export class RootComponent extends React.Component<IRootComponentProps, void> {
             <div className="stack">
                 <div className="container vertical full">
                     <div className="container full">
-                        <div className="stack layer">
+                        <div className="stack">
                             <EditorHost editor={this.props.editor} />
                         </div>
                         <div className="stack layer">
-                            <Cursor />
-                            <CursorLine lineType={"line"} />
-                            <CursorLine lineType={"column"} />
                             <QuickInfoContainer />
                             <SignatureHelpContainer />
                             <AutoCompletionContainer />

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -48,13 +48,18 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
     const opacitySetting = props.lineType === "line" ? "editor.cursorLineOpacity" : "editor.cursorColumnOpacity"
     const opacity = state.configuration[opacitySetting]
 
+    const enabledSetting = props.lineType === "line" ? "editor.cursorLine" : "editor.cursorColumn"
+    const enabled = state.configuration[enabledSetting]
+
+    const isVisible = props.lineType === "line" ? state.cursorLineVisible : state.cursorColumnVisible
+
     return {
         x: props.lineType === "line" ? state.activeWindowDimensions.x : state.cursorPixelX,
         y: props.lineType === "line" ? state.cursorPixelY : state.activeWindowDimensions.y,
         width: props.lineType === "line" ? state.activeWindowDimensions.width : state.cursorPixelWidth,
         height: props.lineType === "line" ? state.fontPixelHeight : state.activeWindowDimensions.height,
         color: state.foregroundColor,
-        visible: props.lineType === "line" ? state.cursorLineVisible : state.cursorColumnVisible,
+        visible: isVisible && enabled,
         opacity
     }
 }

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -43,8 +43,6 @@ class CursorLineRenderer extends React.Component<ICursorLineRendererProps, void>
 }
 
 const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
-
-
     const opacitySetting = props.lineType === "line" ? "editor.cursorLineOpacity" : "editor.cursorColumnOpacity"
     const opacity = state.configuration[opacitySetting]
 
@@ -60,7 +58,7 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
         height: props.lineType === "line" ? state.fontPixelHeight : state.activeWindowDimensions.height,
         color: state.foregroundColor,
         visible: isVisible && enabled,
-        opacity
+        opacity,
     }
 }
 

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -43,6 +43,11 @@ class CursorLineRenderer extends React.Component<ICursorLineRendererProps, void>
 }
 
 const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
+
+
+    const opacitySetting = props.lineType === "line" ? "editor.cursorLineOpacity" : "editor.cursorColumnOpacity"
+    const opacity = state.configuration[opacitySetting]
+
     return {
         x: props.lineType === "line" ? state.activeWindowDimensions.x : state.cursorPixelX,
         y: props.lineType === "line" ? state.cursorPixelY : state.activeWindowDimensions.y,
@@ -50,7 +55,7 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
         height: props.lineType === "line" ? state.fontPixelHeight : state.activeWindowDimensions.height,
         color: state.foregroundColor,
         visible: props.lineType === "line" ? state.cursorLineVisible : state.cursorColumnVisible,
-        opacity: props.lineType === "line" ? state.cursorLineOpacity : state.cursorColumnOpacity,
+        opacity
     }
 }
 

--- a/browser/src/UI/components/EditorHost.tsx
+++ b/browser/src/UI/components/EditorHost.tsx
@@ -13,15 +13,10 @@ export interface IEditorHostProps {
 }
 
 export class EditorHost extends React.Component<IEditorHostProps, void> {
-    private _element: HTMLDivElement
-
-    public componentDidMount(): void {
-        if (this._element) {
-            this.props.editor.render(this._element)
-        }
-    }
 
     public render(): JSX.Element {
-        return <div ref={ (elem) => this._element = elem } className="editor"></div>
+        return <div className="editor">
+            {this.props.editor.render()}
+        </div>
     }
 }

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -47,7 +47,7 @@ export class Menu extends React.Component<IMenuProps, void> {
             onClick={() => this.props.onSelect(false, index)}
             />)
 
-        return <div className="menu-background">
+        return <div className="menu-background enable-mouse-events">
             <div className="menu">
                 <input type="text"
                     ref={(inputElement) => {

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -47,7 +47,7 @@ export class Menu extends React.Component<IMenuProps, void> {
             onClick={() => this.props.onSelect(false, index)}
             />)
 
-        return <div className="menu-background enable-mouse-events">
+        return <div className="menu-background enable-mouse">
             <div className="menu">
                 <input type="text"
                     ref={(inputElement) => {

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -40,7 +40,7 @@ export class StatusBar extends React.PureComponent<StatusBarProps, void> {
             .filter((item) => item.alignment === StatusBarAlignment.Right)
             .sort((a, b) => b.priority - a.priority)
 
-        return <div className="status-bar">
+        return <div className="status-bar enable-mouse">
             <div className="status-bar-inner">
                 <div className="status-bar-container left">
                     {leftItems.map((item) => <StatusBarItem {...item} />)}

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -32,11 +32,11 @@
     bottom: 0px;
 }
 
-.disable-mouse-events {
+.disable-mouse {
     pointer-events: none;
 }
 
-.enable-mouse-events {
+.enable-mouse {
     pointer-events: auto;
 }
 

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -32,6 +32,14 @@
     bottom: 0px;
 }
 
+.disable-mouse-events {
+    pointer-events: none;
+}
+
+.enable-mouse-events {
+    pointer-events: auto;
+}
+
 /* Layer is used to force webkit to promote the element to an individual layer.
     This is used to tweak and control rendering performance, and not for layout */
 .layer {


### PR DESCRIPTION
This is some prepatory refactoring to enable better handling of mouse events for #498 . Previously, the Mouse was attached directly the document body, but this enables it to now be hooked up to the neovim surface. Ideally, the `NeovimSurface` could be refactored out to a completely separate component, and reused elsewhere. 

The next step for this refactoring, eventually, would be to create an `OniSurface` which would be the `NeovimSurface` plus all the Oni-specific stuff like quick info, autocompletion, menus, overlays. It would also be helpful to refactor the overlays to components.

This also helps to open the door for #361 

Remaining work:
- [x] validate no regression in drag & drop