### PR TITLE
Quick Info: Fix issue where quick-info would not be dismissed

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -178,6 +178,8 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
                                     info: quickInfo.title,
                                     documentation: quickInfo.description,
                                 })
+                            } else {
+                                this._channel.send("clear-quick-info", originalContext null)
                             }
                         }, (err) => {
                             this._channel.sendError("show-quick-info", originalContext, err)

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -179,7 +179,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
                                     documentation: quickInfo.description,
                                 })
                             } else {
-                                this._channel.send("clear-quick-info", originalContext null)
+                                this._channel.send("clear-quick-info", originalContext, null)
                             }
                         }, (err) => {
                             this._channel.sendError("show-quick-info", originalContext, err)

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -158,80 +158,82 @@ export class PluginManager extends EventEmitter {
 
         // TODO: Refactor these handlers to separate classes
         // - pluginManager.registerResponseHandler("show-quick-info", new QuickInfoHandler())
-
         switch (pluginResponse.type) {
-        case "show-quick-info":
-            if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
-                return
-            }
-
-            if (!pluginResponse.error) {
+            case "clear-quick-info":
                 UI.Actions.hideQuickInfo()
-                setTimeout(() => {
-                    if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
-                        return
-                    }
-                    UI.Actions.showQuickInfo(pluginResponse.payload.info, pluginResponse.payload.documentation)
-                }, this._config.getValue("editor.quickInfo.delay"))
-            } else {
-                setTimeout(() => UI.Actions.hideQuickInfo())
-            }
-            break
-        case "goto-definition":
-            if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
-                return
-            }
+                break
+            case "show-quick-info":
+                if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
+                    return
+                }
 
-            // TODO: Refactor to 'Service', break remaining NeoVim dependencies
-            const { filePath, line, column } = pluginResponse.payload
-            this._neovimInstance.command("e! " + filePath)
-            this._neovimInstance.command(`cal cursor(${line}, ${column})`)
-            this._neovimInstance.command("norm zz")
-            break
-        case "completion-provider":
-            if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
-                return
-            }
+                if (!pluginResponse.error) {
+                    UI.Actions.hideQuickInfo()
+                    setTimeout(() => {
+                        if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
+                            return
+                        }
+                        UI.Actions.showQuickInfo(pluginResponse.payload.info, pluginResponse.payload.documentation)
+                    }, this._config.getValue("editor.quickInfo.delay"))
+                } else {
+                    setTimeout(() => UI.Actions.hideQuickInfo())
+                }
+                break
+            case "goto-definition":
+                if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
+                    return
+                }
 
-            if (!pluginResponse.payload) {
-                return
-            }
+                // TODO: Refactor to 'Service', break remaining NeoVim dependencies
+                const { filePath, line, column } = pluginResponse.payload
+                this._neovimInstance.command("e! " + filePath)
+                this._neovimInstance.command(`cal cursor(${line}, ${column})`)
+                this._neovimInstance.command("norm zz")
+                break
+            case "completion-provider":
+                if (!this._validateOriginEventMatchesCurrentEvent(pluginResponse)) {
+                    return
+                }
 
-            setTimeout(() => UI.Actions.showCompletions(pluginResponse.payload))
-            break
-        case "completion-provider-item-selected":
-            setTimeout(() => UI.Actions.setDetailedCompletionEntry(pluginResponse.payload.details))
-            break
-        case "set-errors":
-            this.emit("set-errors", pluginResponse.payload.key, pluginResponse.payload.fileName, pluginResponse.payload.errors, pluginResponse.payload.color)
-            break
-        case "find-all-references":
-            this.emit("find-all-references", pluginResponse.payload.references)
-            break
-        case "format":
-            this.emit("format", pluginResponse.payload)
-            break
-        case "execute-shell-command":
-            // TODO: Check plugin permission
-            this.emit("execute-shell-command", pluginResponse.payload)
-            break
-        case "evaluate-block-result":
-            this.emit("evaluate-block-result", pluginResponse.payload)
-            break
-        case "set-syntax-highlights":
-            this.emit("set-syntax-highlights", pluginResponse.payload)
-            break
-        case "clear-syntax-highlights":
-            this.emit("clear-syntax-highlights", pluginResponse.payload)
-            break
-        case "signature-help-response":
-            this.emit("signature-help-response", pluginResponse.error, pluginResponse.payload)
-            break
-        case "redux-action":
-            UI.store.dispatch(pluginResponse.payload)
-            break
-        default:
-            this.emit("logWarning", "Unexpected plugin type: " + pluginResponse.type)
+                if (!pluginResponse.payload) {
+                    return
+                }
+
+                setTimeout(() => UI.Actions.showCompletions(pluginResponse.payload))
+                break
+            case "completion-provider-item-selected":
+                setTimeout(() => UI.Actions.setDetailedCompletionEntry(pluginResponse.payload.details))
+                break
+            case "set-errors":
+                this.emit("set-errors", pluginResponse.payload.key, pluginResponse.payload.fileName, pluginResponse.payload.errors, pluginResponse.payload.color)
+                break
+            case "find-all-references":
+                this.emit("find-all-references", pluginResponse.payload.references)
+                break
+            case "format":
+                this.emit("format", pluginResponse.payload)
+                break
+            case "execute-shell-command":
+                // TODO: Check plugin permission
+                this.emit("execute-shell-command", pluginResponse.payload)
+                break
+            case "evaluate-block-result":
+                this.emit("evaluate-block-result", pluginResponse.payload)
+                break
+            case "set-syntax-highlights":
+                this.emit("set-syntax-highlights", pluginResponse.payload)
+                break
+            case "clear-syntax-highlights":
+                this.emit("clear-syntax-highlights", pluginResponse.payload)
+                break
+            case "signature-help-response":
+                this.emit("signature-help-response", pluginResponse.error, pluginResponse.payload)
+                break
+            case "redux-action":
+                UI.store.dispatch(pluginResponse.payload)
+                break
+            default:
+                this.emit("logWarning", "Unexpected plugin type: " + pluginResponse.type)
         }
     }
 

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -4,6 +4,8 @@
     transition: all 0.5s;
     animation-name: appear;
     animation-duration: 0.5s;
+    -webkit-user-select: none;
+    cursor: default;
 
     .quickinfo {
         .box-shadow;

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -11,7 +11,6 @@
         .box-shadow;
 
         background-color: @background-color;
-        // padding: 4px;
         color: @text-color;
         text-overflow: ellipsis;
         overflow: hidden;

--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -9,7 +9,7 @@
         .box-shadow;
 
         background-color: @background-color;
-        padding: 4px;
+        // padding: 4px;
         color: @text-color;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -17,13 +17,16 @@
         .title {
             width: 100%;
             white-space: nowrap;
-            margin: 4px;
+            margin: 8px;
         }
 
         .documentation {
-            margin: 4px;
+            .box-shadow-inset;
+            padding: 8px;
             color: @text-color-detail;
             font-size: @font-size-small;
+            max-height: 48px;
+            overflow-y: auto;
         }
 
         .selected {

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -75,6 +75,10 @@ export class QuickInfoTitle extends TextComponent {
 export class QuickInfoDocumentation extends TextComponent {
     public render(): JSX.Element {
 
+        if (!this.props.text) {
+            return null
+        }
+
         const lines = this.props.text.split(os.EOL)
         const divs = lines.map((l) => <div>{l}</div>)
 
@@ -154,9 +158,11 @@ const mapStateToSignatureHelpProps = (state: IState): IQuickInfoProps => {
           parameters.splice(i, 0, <Text text={currentItem.separator + " "} />)
         }
 
-        let elements = [<Text text={currentItem.prefix} />]
+        let titleContents = [<Text text={currentItem.prefix} />]
             .concat(parameters)
             .concat([<Text text={currentItem.suffix} />])
+
+        let elements = [<div className="title">{titleContents}</div>]
 
         const selectedIndex = Math.min(currentItem.parameters.length, state.signatureHelp.argumentIndex)
         const selectedArgument = currentItem.parameters[selectedIndex]

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -50,7 +50,7 @@ export class QuickInfo extends React.Component<IQuickInfoProps, void> {
 
         const innerStyle = openFromTop ? openFromTopStyle : openFromBottomStyle
 
-        return <div key={"quickinfo-container"} className="quickinfo-container" style={containerStyle}>
+        return <div key={"quickinfo-container"} className="quickinfo-container enable-mouse" style={containerStyle}>
             <div key={"quickInfo"} style={innerStyle} className="quickinfo">
                 {this.props.elements}
             </div>


### PR DESCRIPTION
__Issue:__ When using quick-info, there would be cases in the LSP client where you could get quick-info, and then move, and the quick-info would stay around. This is very annoying.

__Fix:__ Some LSP providers don't send back an error in this case, and just return a null result. In that case, we should handle it and clear it out. 

I also took an opportunity to add a scrollbar (similiar to the completion details)