### PR TITLE
Fix #509: Upgrade `vscode-jsonrpc` and `vscode-languageserver-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,8 @@
     "spectron": "3.6.2",
     "style-loader": "0.13.1",
     "ts-loader": "1.2.2",
-    "vscode-jsonrpc": "3.2.0",
-    "vscode-languageserver-types": "3.2.0",
+    "vscode-jsonrpc": "3.3.1",
+    "vscode-languageserver-types": "3.3.0",
     "wcwidth": "1.0.1",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.1"


### PR DESCRIPTION
Looks like `omnisharp-node-client` depends on a newer version of `vscode-jsonrpc`, which exposes a message queue and connection strategy interface.