### PR TITLE
Fix #511: Only execute completion requests if LS supports it

### DIFF
--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -32,9 +32,23 @@ export namespace TextDocumentSyncKind {
     export const Incremental = 2
 }
 
+export interface CompletionOptions {
+	/**
+	 * The server provides support to resolve additional
+	 * information for a completion item.
+	 */
+	resolveProvider?: boolean;
+
+	/**
+	 * The characters that trigger completion automatically.
+	 */
+	triggerCharacters?: string[];
+}
+
 // ServerCapabilities
 // Defined in the LSP protocol: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
 export interface ServerCapabilities {
+    completionProvider?: CompletionOptions
     textDocumentSync?: number
 }
 

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -33,16 +33,16 @@ export namespace TextDocumentSyncKind {
 }
 
 export interface CompletionOptions {
-	/**
-	 * The server provides support to resolve additional
-	 * information for a completion item.
-	 */
-	resolveProvider?: boolean;
+    /**
+     * The server provides support to resolve additional
+     * information for a completion item.
+     */
+    resolveProvider?: boolean
 
-	/**
-	 * The characters that trigger completion automatically.
-	 */
-	triggerCharacters?: string[];
+    /**
+     * The characters that trigger completion automatically.
+     */
+    triggerCharacters?: string[]
 }
 
 // ServerCapabilities
@@ -135,9 +135,9 @@ const splitByNewlines = (str: string) => {
 }
 
 const getFilePrefix = () => {
-     if (process.platform === "win32") {
-         return "file:///"
-     } else {
-         return "file://"
-     }
+    if (process.platform === "win32") {
+        return "file:///"
+    } else {
+        return "file://"
+    }
  }


### PR DESCRIPTION
__Issue:__ We always ask for completions.. even if the language server doesn't support it. This causes unnecessary errors.

__Fix:__ Use the completion provider capability to check before executing the request.