### PR TITLE
Open multiple files in tabs/splits.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,9 @@
             "cwd": "${workspaceRoot}",
             "program": "${workspaceRoot}/main.js",
             "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "windows": {
+                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+            },
             "runtimeArgs": [
                 "--enable-logging"
             ],
@@ -21,6 +24,9 @@
             "type": "chrome", // <-- requires Extension "Debugger for Chrome"
             "request": "launch",
             "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "windows": {
+                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+            },
             "runtimeArgs": [
                 "--enable-logging",
                 "${workspaceRoot}/main.js"

--- a/Menu.js
+++ b/Menu.js
@@ -60,7 +60,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 label: 'Split Open...',
                 click: (item, focusedWindow) => {
                     dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
-                        executeVimCommandForMultipleFiles(":sp", files)
+                        executeVimCommandForMultipleFiles(":sp ", files)
                     })
                 }
             },
@@ -68,7 +68,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 label: 'Tab Open...',
                 click: (item, focusedWindow) => {
                     dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
-                        executeVimCommandForMultipleFiles(":tabnew", files)
+                        executeVimCommandForMultipleFiles(":tabnew ", files)
                     })
                 }
             },

--- a/Menu.js
+++ b/Menu.js
@@ -59,8 +59,8 @@ const buildMenu = (mainWindow, loadInit) => {
             {
                 label: 'Split Open...',
                 click: (item, focusedWindow) => {
-                    dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
-                        executeVimCommandForMultipleFiles(":sp ", files)
+                    dialog.showOpenDialog(mainWindow, 'openFile', (files) => {
+                        executeVimCommandForFiles(":sp", files)
                     })
                 }
             },

--- a/Menu.js
+++ b/Menu.js
@@ -15,6 +15,8 @@ const buildMenu = (mainWindow, loadInit) => {
 
     const executeVimCommand = (command) => mainWindow.webContents.send("menu-item-click", command)
 
+    const executeVimCommandForMultipleFiles = (command, files) => mainWindow.webContents.send("open-files", command, files)
+
     const executeOniCommand = (command) => mainWindow.webContents.send("execute-command", command)
 
     const executeVimCommandForFiles = (command, files) => {
@@ -58,7 +60,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 label: 'Split Open...',
                 click: (item, focusedWindow) => {
                     dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
-                        executeVimCommandForFiles(":sp", files)
+                        executeVimCommandForMultipleFiles(":sp", files)
                     })
                 }
             },
@@ -66,7 +68,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 label: 'Tab Open...',
                 click: (item, focusedWindow) => {
                     dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
-                        executeVimCommandForFiles(":tabnew", files)
+                        executeVimCommandForMultipleFiles(":tabnew", files)
                     })
                 }
             },

--- a/Menu.js
+++ b/Menu.js
@@ -57,7 +57,7 @@ const buildMenu = (mainWindow, loadInit) => {
             {
                 label: 'Split Open...',
                 click: (item, focusedWindow) => {
-                    dialog.showOpenDialog(mainWindow, ['openFile'], (files) => {
+                    dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
                         executeVimCommandForFiles(":sp", files)
                     })
                 }
@@ -65,7 +65,7 @@ const buildMenu = (mainWindow, loadInit) => {
             {
                 label: 'Tab Open...',
                 click: (item, focusedWindow) => {
-                    dialog.showOpenDialog(mainWindow, ['openFile'], (files) => {
+                    dialog.showOpenDialog(mainWindow, {properties: ['openFile', 'multiSelections']}, (files) => {
                         executeVimCommandForFiles(":tabnew", files)
                     })
                 }

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -285,26 +285,17 @@ export class NeovimEditor implements IEditor {
 
         const normalizePath = (fileName: string) => fileName.split("\\").join("/")
 
-        ipcRenderer.on("open-files", (_evt: any, message: string, files: string[]) => {
+        const openFiles = async (files: string[], action: string) => {
 
-            // Open the first file.
-            // If the current buffer is named, then open in a new tab or split.
-            // If the current buffer has modifications pending, then open in a new tab or split.
-            // If the current buffer had no modification and is a new file, open in the current buffer.
+            await this._neovimInstance.callFunction("OniOpenFile", [action, files[0]])
 
-            this._neovimInstance.command("if bufname('%') != ''\n" +
-                        "    exec \"" + message + normalizePath(files[0]) + "\"\n" +
-                        "elseif &modified\n" +
-                        "    exec \"" + message + normalizePath(files[0]) + "\"\n" +
-                        "else\n" +
-                        "    exec \":e " + normalizePath(files[0]) + "\"\n" + 
-                        "endif")
-
-            // Open any subsequent files in a tab or split.
             for (let i = 1; i < files.length; i++) {
-                this._neovimInstance.command("exec \"" + message + " " + normalizePath(files[i]) + "\"")
+                this._neovimInstance.command("exec \"" + action + " " + normalizePath(files[i]) + "\"")
             }
+        }
 
+        ipcRenderer.on("open-files", (_evt: any, message: string, files: string[]) => {
+            openFiles(files, message)
         })
 
         // enable opening a file via drag-drop

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -283,6 +283,10 @@ export class NeovimEditor implements IEditor {
             }
         })
 
+        ipcRenderer.on("open-files", (_evt: any, message: string, files: string[]) => {
+
+        })
+
         // enable opening a file via drag-drop
         document.ondragover = (ev) => {
             ev.preventDefault()

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -30,6 +30,16 @@ function OniNotifyEvent(eventName)
     call OniNotify(["event", a:eventName, context])
 endfunction
 
+function OniOpenFile(strategy, file)
+    if bufname('%') != ''
+        exec a:strategy . a:file
+    elseif &modified
+        exec a:strategy . a:file
+    else
+        exec ":e " . a:file
+    endif
+endfunction
+
 augroup OniNotifyBufferUpdates
     autocmd!
     autocmd! CursorMovedI * :call OniNotifyBufferUpdate()


### PR DESCRIPTION
Just putting this here so anyone can have a glance over as I'm doing it.

Currently, I'm calling some VimL to work out if the first file should be opened in the current buffer, or if it should be opened in a tab / split. The other files are then just opened in turn.

Works fine for tabs (at least how I expect it to, but I'm fine with changing it if needed), splits have an issue that I think is to do with buffer change issues...

A smarter way of doing this may be to use the `getCurrentBuffer()` command, and then do some checks against that instead? Think that would require getting the current filename, the changed state, and which buffer it is.
Looks like the functions for that are in the Buffer.ts file, but I can't work out how they link to nvim.