### PR TITLE
Round of quickinfo (and signature help) fixes

### DIFF
--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -17,7 +17,6 @@
 
         .title {
             width: 100%;
-            white-space: nowrap;
             margin: 8px;
         }
 

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -9,7 +9,6 @@ require("./QuickInfo.less") // tslint:disable-line no-var-requires
 
 export interface IQuickInfoProps {
     visible: boolean
-    wrap: boolean
     x: number
     y: number
     elements: JSX.Element[]
@@ -34,7 +33,6 @@ export class QuickInfo extends React.Component<IQuickInfoProps, void> {
         const innerCommonStyle = {
             "position": "absolute",
             "opacity": this.props.visible ? 1 : 0,
-            "whiteSpace": this.props.wrap ? "normal" : "nowrap",
             "max-width": (document.body.offsetWidth - this.props.x - 40) + "px",
         }
 
@@ -98,7 +96,7 @@ export class SelectedText extends TextComponent {
     }
 }
 
-const mapStateToQuickInfoProps = (state: IState): IQuickInfoProps => {
+const getOpenPosition = (state: IState): { x: number, y: number, openFromTop: boolean } => {
     const openFromTopPosition = state.cursorPixelY + (state.fontPixelHeight * 2)
     const openFromBottomPosition = state.cursorPixelY - state.fontPixelHeight
 
@@ -106,22 +104,26 @@ const mapStateToQuickInfoProps = (state: IState): IQuickInfoProps => {
 
     const yPos = openFromTop ? openFromTopPosition : openFromBottomPosition
 
+    return {
+        x: state.cursorPixelX,
+        y: yPos,
+        openFromTop,
+    }
+}
+
+const mapStateToQuickInfoProps = (state: IState): IQuickInfoProps => {
+    const openPosition = getOpenPosition(state)
+
     if (!state.quickInfo) {
         return {
-            wrap: true,
+            ...openPosition,
             visible: false,
-            x: state.cursorPixelX,
-            y: yPos,
             elements: [],
-            openFromTop,
         }
     } else {
         return {
-            wrap: true,
+            ...openPosition,
             visible: true,
-            x: state.cursorPixelX,
-            y: yPos,
-            openFromTop,
             elements: [
                 <QuickInfoTitle text={state.quickInfo.title} />,
                 <QuickInfoDocumentation text={state.quickInfo.description} />,
@@ -131,13 +133,12 @@ const mapStateToQuickInfoProps = (state: IState): IQuickInfoProps => {
 }
 
 const mapStateToSignatureHelpProps = (state: IState): IQuickInfoProps => {
+    const openPosition = getOpenPosition(state)
 
     if (!state.signatureHelp) {
         return {
-            wrap: false,
+            ...openPosition,
             visible: false,
-            x: state.cursorPixelX,
-            y: state.cursorPixelY - (state.fontPixelHeight),
             elements: [],
         }
     } else {
@@ -171,10 +172,8 @@ const mapStateToSignatureHelpProps = (state: IState): IQuickInfoProps => {
         }
 
         return {
-            wrap: false,
+            ...openPosition,
             visible: true,
-            x: state.cursorPixelX,
-            y: state.cursorPixelY - (state.fontPixelHeight),
             elements,
         }
     }

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -102,7 +102,7 @@ const mapStateToQuickInfoProps = (state: IState): IQuickInfoProps => {
     const openFromTopPosition = state.cursorPixelY + (state.fontPixelHeight * 2)
     const openFromBottomPosition = state.cursorPixelY - state.fontPixelHeight
 
-    const openFromTop = state.cursorPixelY < 50
+    const openFromTop = state.cursorPixelY < 75
 
     const yPos = openFromTop ? openFromTopPosition : openFromBottomPosition
 


### PR DESCRIPTION
This fixes a few minor issues with quickinfo:
- Switch to `openFromBottom` more aggressively near the top
- Allow both quickinfo and signature help to wrap.