### PR TITLE
Fix #331 & #401: Update the mode-change event to take the LAST mode reported by Neovim

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -394,7 +394,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 this.emit("action", Actions.updateForeground(a[0][0]))
                 break
             case "mode_change":
-                const newMode = a[0][0]
+                const newMode = a[a.length - 1][0]
                 this.emit("action", Actions.changeMode(newMode))
                 this.emit("mode-change", newMode)
                 break


### PR DESCRIPTION
Fixes #331 and #401 

__Issue:__ On the `mode-change` event, we are receiving multiple modes from Neovim in some cases. See #331 for details. We always pick the _first_ mode in this array, but in actuality, the _last_ mode is the correct mode.

__Fix:__ Pick the last mode on `mode-change`