### PR TITLE
Fix #500: Handle hide-popup-menu event

### DIFF
--- a/browser/src/NeovimInstance.ts
+++ b/browser/src/NeovimInstance.ts
@@ -398,6 +398,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 this.emit("action", Actions.changeMode(newMode))
                 this.emit("mode-change", newMode)
                 break
+            case "popupmenu_hide":
+                this.emit("hide-popup-menu")
+                break
             case "popupmenu_show":
                 const completions = a[0][0]
                 this.emit("show-popup-menu", completions)

--- a/browser/src/Services/AutoCompletion.ts
+++ b/browser/src/Services/AutoCompletion.ts
@@ -31,6 +31,10 @@ export class AutoCompletion {
                 completions: c,
             })
         })
+
+        this._neovimInstance.on("hide-popup-menu", () => {
+            UI.Actions.hideCompletions()
+        })
     }
 
     public complete(): void {


### PR DESCRIPTION
Add handling for the `hide-popup-menu` event from Neovim. When Neovim's completion is open, and space is pressed / we move outside the word, it'll trigger this event.