### PR TITLE
Fix #547 - positioning issues with error markers from the LSP

### DIFF
--- a/browser/src/Services/Errors.ts
+++ b/browser/src/Services/Errors.ts
@@ -61,7 +61,7 @@ export class Errors implements ITaskProvider {
         const errors = flattenedErrors.map((e) => <any>({
             filename: e.filename,
             col: e.range.start.character || 0,
-            lnum: e.range.start.line,
+            lnum: e.range.start.line + 1,
             text: e.message,
         }))
 

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -36,8 +36,8 @@ export class Errors extends React.PureComponent<IErrorsProps, void> {
         const windowContext = new WindowContext2(this.props.fontWidthInPixels, this.props.fontHeightInPixels, this.props.window)
 
         const markers = errors.map((e) => {
-            const lineNumber = e.range.start.line
-            const column = e.range.start.character
+            const lineNumber = e.range.start.line + 1
+            const column = e.range.start.character + 1
             if (windowContext.isLineInView(lineNumber)) {
                 const screenLine = windowContext.getWindowLine(lineNumber)
 
@@ -62,9 +62,9 @@ export class Errors extends React.PureComponent<IErrorsProps, void> {
         const squiggles = errors
             .filter((e) => e && e.range && e.range.start && e.range.end)
             .map((e) => {
-            const lineNumber = e.range.start.line
-            const column = e.range.start.character
-            const endColumn = e.range.end.character
+            const lineNumber = e.range.start.line + 1
+            const column = e.range.start.character + 1
+            const endColumn = e.range.end.character + 1
 
             if (windowContext.isLineInView(lineNumber)) {
                 const yPos = windowContext.getWindowRegionForLine(lineNumber).y

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -15,8 +15,6 @@ import { measureFont } from "./../Font"
 import { PluginManager } from "./../Plugins/PluginManager"
 import { IPixelPosition, IPosition } from "./../Screen"
 
-derp
-
 export interface INeovimInstance {
     cursorPosition: IPosition
     quickFix: IQuickFixList

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -15,6 +15,8 @@ import { measureFont } from "./../Font"
 import { PluginManager } from "./../Plugins/PluginManager"
 import { IPixelPosition, IPosition } from "./../Screen"
 
+derp
+
 export interface INeovimInstance {
     cursorPosition: IPosition
     quickFix: IQuickFixList

--- a/vim/core/oni-plugin-tslint/lib/index.js
+++ b/vim/core/oni-plugin-tslint/lib/index.js
@@ -126,11 +126,11 @@ const activate = (Oni) => {
                     severity: 2 /* Warning */,
                     range: {
                         start: {
-                            line: e.startPosition.line + 1,
-                            character: e.startPosition.character + 1,
+                            line: e.startPosition.line,
+                            character: e.startPosition.character,
                         },
                         end: {
-                            line: e.endPosition.line + 1,
+                            line: e.endPosition.line,
                             character: e.endPosition.character
                         }
                     }

--- a/vim/core/oni-plugin-typescript/src/index.ts
+++ b/vim/core/oni-plugin-typescript/src/index.ts
@@ -269,14 +269,14 @@ export const activate = (Oni) => {
     })
 
     host.on("semanticDiag", (diagnostics) => {
-
         const fileName = diagnostics.file
 
         const diags = diagnostics.diagnostics || []
 
         const errors = diags.map((d) => {
-            const startPosition = Position.create(d.start.line, d.start.offset)
-            const endPosition = Position.create(d.end.line, d.end.offset)
+            // Convert lines to zero-based to accomodate protocol
+            const startPosition = Position.create(d.start.line - 1, d.start.offset)
+            const endPosition = Position.create(d.end.line - 1, d.end.offset)
             const range = Range.create(startPosition, endPosition)
 
             return {


### PR DESCRIPTION
There was an off-by-one issue - the error markers assumed a 'one-based' protocol for the line numbers, as this is what the typescript language server uses. However, the language server protocol specifices a 'zero-based' protocol - since much of the code is common between the strategies, one of them wasn't going to work correctly.

The fix is to move to a consistent protocol, with the LSP taking precedence, so the code now handles a 'zero-based' protocol.