### PR TITLE
Part 1 of fix for #484 - fix issue where Oni won't open from dock

### DIFF
--- a/main.js
+++ b/main.js
@@ -121,7 +121,7 @@ app.on('activate', function() {
     // On OS X it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (windows.length === 0) {
-        createWindow()
+        createWindow([], process.cwd())
     }
 })
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "concurrently": "3.1.0",
     "cross-env": "3.1.3",
     "css-loader": "0.26.1",
-    "electron": "1.7.4",
+    "electron": "1.6.11",
     "electron-builder": "16.4.2",
     "electron-devtools-installer": "2.1.0",
     "extract-zip": "1.6.0",


### PR DESCRIPTION
This fixes a couple of issues opening Oni on OSX:
1) Oni won't open from dock - this was due to an incorrect call to `createWindow` without the full set of supplied parameters
2) Oni won't open from terminal, if there is an instance already open. This is an issue with Electron 1.7.4, specifically electron/electron#9880 and electron/electron#9965