### PR TITLE
Fix #553: Add additional, optional paths to spawned processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ A few interesting configuration options to set:
 - `editor.backgroundImageUrl` - specific a custom background image
 - `editor.backgroundImageSize` - specific a custom background size (cover, contain)
 - `editor.scrollBar.visible` - (default: `true`) sets whether the buffer scrollbar is visible
+- `environment.additionalPaths` - (default: `[] on Windows, ['/usr/bin', '/usr/local/bin'] on OSX and Linux`). Sets additional paths for binaries. This may be necessary to configure, if using plugins or a Language Server that is not in the default set of runtime paths. Note that depending on where you launch Oni, there may be a different set of runtime paths sent to it - you can always check by opening the developer tools and running `process.env.PATH` in the console.
 
 See the `Config.ts` file for other interesting values to set.
 

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -73,6 +73,10 @@ export interface IConfigValues {
     // If true (default), the buffer scroll bar will be visible
     "editor.scrollBar.visible": boolean
 
+    // Additional paths to include when launching sub-process from Oni
+    // (and available in terminal integration, later)
+    "environment.additionalPaths": string[]
+
     // Command to list files for 'quick open'
     // For example, to use 'ag': ag --nocolor -l .
     //
@@ -144,6 +148,8 @@ export class Config extends EventEmitter {
         "editor.cursorColumn": false,
         "editor.cursorColumnOpacity": 0.1,
 
+        "environment.additionalPaths": [],
+
         "statusbar.enabled": true,
         "statusbar.fontSize": "12px",
     }
@@ -152,6 +158,10 @@ export class Config extends EventEmitter {
         "editor.fontFamily": "Menlo",
         "editor.fontSize": "12px",
         "statusbar.fontSize": "10px",
+        "environment.additionalPaths": [
+            "/usr/bin",
+            "/usr/local/bin",
+        ],
     }
 
     private WindowsConfig: Partial<IConfigValues> = {

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -172,6 +172,10 @@ export class Config extends EventEmitter {
     private LinuxConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "DejaVu Sans Mono",
         "statusbar.fontSize": "11px",
+        "environment.additionalPaths": [
+            "/usr/bin",
+            "/usr/local/bin",
+        ],
     }
 
     private DefaultPlatformConfig = Platform.isWindows() ? this.WindowsConfig : Platform.isLinux() ? this.LinuxConfig : this.MacConfig

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -156,7 +156,7 @@ export class LanguageClient {
         const startArgs = this._startOptions.args || []
 
         const options = {
-            cwd: process.cwd()
+            cwd: process.cwd(),
         }
 
         if (this._startOptions.command) {

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -11,7 +11,7 @@ import * as _ from "lodash"
 import * as rpc from "vscode-jsonrpc"
 import * as types from "vscode-languageserver-types"
 
-import { ChildProcess, spawn } from "child_process"
+import { ChildProcess } from "child_process"
 
 import { getCompletionMeet } from "./../../../Services/AutoCompletionUtility"
 import { Oni } from "./../Oni"
@@ -157,7 +157,7 @@ export class LanguageClient {
 
         if (this._startOptions.command) {
             console.log(`[LANGUAGE CLIENT]: Starting process via '${this._startOptions.command}`) // tslint:disable-line no-console
-            this._process = spawn(this._startOptions.command, startArgs)
+            this._process = this._oni.spawnProcess(this._startOptions.command, startArgs)
         } else if (this._startOptions.module) {
             console.log(`[LANGUAGE CLIENT]: Starting process via node script '${this._startOptions.module}`) // tslint:disable-line no-console
             this._process = this._oni.spawnNodeScript(this._startOptions.module, startArgs)

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -155,12 +155,16 @@ export class LanguageClient {
     public start(initializationParams: LanguageClientInitializationParams): Thenable<any> {
         const startArgs = this._startOptions.args || []
 
+        const options = {
+            cwd: process.cwd()
+        }
+
         if (this._startOptions.command) {
             console.log(`[LANGUAGE CLIENT]: Starting process via '${this._startOptions.command}`) // tslint:disable-line no-console
-            this._process = this._oni.process.spawnProcess(this._startOptions.command, startArgs)
+            this._process = this._oni.process.spawnProcess(this._startOptions.command, startArgs, options)
         } else if (this._startOptions.module) {
             console.log(`[LANGUAGE CLIENT]: Starting process via node script '${this._startOptions.module}`) // tslint:disable-line no-console
-            this._process = this._oni.process.spawnNodeScript(this._startOptions.module, startArgs)
+            this._process = this._oni.process.spawnNodeScript(this._startOptions.module, startArgs, options)
         } else {
             throw "A command or module must be specified to start the server"
         }

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -157,10 +157,10 @@ export class LanguageClient {
 
         if (this._startOptions.command) {
             console.log(`[LANGUAGE CLIENT]: Starting process via '${this._startOptions.command}`) // tslint:disable-line no-console
-            this._process = this._oni.spawnProcess(this._startOptions.command, startArgs)
+            this._process = this._oni.process.spawnProcess(this._startOptions.command, startArgs)
         } else if (this._startOptions.module) {
             console.log(`[LANGUAGE CLIENT]: Starting process via node script '${this._startOptions.module}`) // tslint:disable-line no-console
-            this._process = this._oni.spawnNodeScript(this._startOptions.module, startArgs)
+            this._process = this._oni.process.spawnNodeScript(this._startOptions.module, startArgs)
         } else {
             throw "A command or module must be specified to start the server"
         }

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -160,10 +160,10 @@ export class LanguageClient {
         }
 
         if (this._startOptions.command) {
-            console.log(`[LANGUAGE CLIENT]: Starting process via '${this._startOptions.command}`) // tslint:disable-line no-console
+            console.log(`[LANGUAGE CLIENT]: Starting process via '${this._startOptions.command}'`) // tslint:disable-line no-console
             this._process = this._oni.process.spawnProcess(this._startOptions.command, startArgs, options)
         } else if (this._startOptions.module) {
-            console.log(`[LANGUAGE CLIENT]: Starting process via node script '${this._startOptions.module}`) // tslint:disable-line no-console
+            console.log(`[LANGUAGE CLIENT]: Starting process via node script '${this._startOptions.module}'`) // tslint:disable-line no-console
             this._process = this._oni.process.spawnNodeScript(this._startOptions.module, startArgs, options)
         } else {
             throw "A command or module must be specified to start the server"

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -60,6 +60,10 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         return this._editor
     }
 
+    public get process(): Oni.Process {
+        return this._process
+    }
+
     public get statusBar(): StatusBar {
         return this._statusBar
     }
@@ -99,7 +103,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
     }
 
     public execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess {
-        console.warn("WARNING: `Oni.execNodeScript` is deprecated. Please use `Oni.process.execNodeScript` instead) // tslint:disable-line no-console-log
+        console.warn("WARNING: `Oni.execNodeScript` is deprecated. Please use `Oni.process.execNodeScript` instead") // tslint:disable-line no-console-log
 
         return this._process.execNodeScript(scriptPath, args, options, callback)
     }
@@ -109,7 +113,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
      */
     public spawnNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): ChildProcess.ChildProcess {
 
-        console.warn("WARNING: `Oni.spawnNodeScript` is deprecated. Please use `Oni.process.spawnNodeScript` instead) // tslint:disable-line no-console-log
+        console.warn("WARNING: `Oni.spawnNodeScript` is deprecated. Please use `Oni.process.spawnNodeScript` instead") // tslint:disable-line no-console-log
 
         return this._process.spawnNodeScript(scriptPath, args, options)
     }

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -1,0 +1,76 @@
+import * as ChildProcess from "child_process"
+
+/**
+ * API surface area responsible for handling process-related tasks
+ * (spawning processes, managing running process, etc)
+ */
+export class Process {
+
+    public execNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.ExecOptions = {}, callback: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess {
+        const requiredOptions = {
+            env: {
+                ...process.env,
+                ELECTRON_RUN_AS_NODE: 1,
+            },
+        }
+
+        const opts = {
+            ...options,
+            ...requiredOptions,
+        }
+
+        const execOptions = [process.execPath, scriptPath].concat(args)
+        const execString = execOptions.map((s) => `"${s}"`).join(" ")
+
+        return ChildProcess.exec(execString, opts, callback)
+    }
+
+    /**
+     * Wrapper around `child_process.exec` to run using electron as opposed to node
+     */
+    public spawnNodeScript(scriptPath: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): ChildProcess.ChildProcess {
+
+        const spawnOptions = this._mergeSpawnOptions(options)
+
+        // Need to merge in `ELECTRON_RUN_AS_NODE` environment variable
+        const requiredOptions = {
+            env: {
+                ...spawnOptions.env,
+                ELECTRON_RUN_AS_NODE: 1,
+            },
+        }
+
+        const finalOpts = {
+            ...spawnOptions,
+            ...requiredOptions,
+        }
+
+        const allArgs = [scriptPath].concat(args)
+
+        return ChildProcess.spawn(process.execPath, allArgs, finalOpts)
+    }
+
+    /**
+     * Spawn process - wrapper around `child_process.spawn`
+     */
+    public spawnProcess(startCommand: string, args: string[] = [], options: ChildProcess.SpawnOptions = {}): ChildProcess.ChildProcess {
+
+        const spawnOptions = this._mergeSpawnOptions(options)
+
+        return ChildProcess.spawn(startCommand, args, spawnOptions)
+    }
+
+    private _mergeSpawnOptions(originalSpawnOptions: ChildProcess.SpawnOptions): ChildProcess.SpawnOptions {
+        // TODO: Append environment variables
+        const requiredOptions = {
+            env: {
+                ...process.env,
+            },
+        }
+
+        return {
+            ...requiredOptions,
+            ...originalSpawnOptions,
+        }
+    }
+}

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -27,12 +27,9 @@ const mergeSpawnOptions = (originalSpawnOptions: ChildProcess.ExecOptions | Chil
         },
     }
 
-    let pathEnvironmentVariableName = "PATH"
-    if (!process.env.PATH) {
-        pathEnvironmentVariableName = "Path"
-    }
+    const existingPath = process.env.Path || process.env.PATH
 
-    requiredOptions.env[pathEnvironmentVariableName] = mergePathEnvironmentVariable(requiredOptions.env[pathEnvironmentVariableName], Config.instance().getValue("environment.additionalPaths"))
+    requiredOptions.env.PATH = mergePathEnvironmentVariable(existingPath, Config.instance().getValue("environment.additionalPaths"))
 
     return {
         ...originalSpawnOptions,

--- a/browser/src/Plugins/Api/Process.ts
+++ b/browser/src/Plugins/Api/Process.ts
@@ -19,26 +19,25 @@ const mergePathEnvironmentVariable = (currentPath: string, pathsToAdd: string[])
     return currentPath + separator + joinedPathsToAdd + separator
 }
 
-
 const mergeSpawnOptions = (originalSpawnOptions: ChildProcess.ExecOptions | ChildProcess.SpawnOptions): any => {
-
     const requiredOptions = {
         env: {
             ...process.env,
-            ...originalSpawnOptions,
+            ...originalSpawnOptions.env,
         },
     }
-
 
     let pathEnvironmentVariableName = "PATH"
     if (!process.env.PATH) {
         pathEnvironmentVariableName = "Path"
     }
 
-
     requiredOptions.env[pathEnvironmentVariableName] = mergePathEnvironmentVariable(requiredOptions.env[pathEnvironmentVariableName], Config.instance().getValue("environment.additionalPaths"))
 
-    return requiredOptions
+    return {
+        ...originalSpawnOptions,
+        ...requiredOptions,
+    }
 }
 
 /**

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -30,6 +30,12 @@ declare namespace Oni {
         createItem(alignment: number, priority: number, globalId?: string): StatusBarItem
     }
 
+    export interface Process {
+        execNodeScript(scriptPath: string, args: string[], options: ChildProcess.ExecOptions, callback: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess
+        spawnNodeScript(scriptPath: string, args: string[], options: ChildProcess.SpawnOptions): ChildProcess.ChildProcess
+        spawnProcess(startCommand: string, args: string[], options: ChildProcess.SpawnOptions): ChildProcess.ChildProcess
+    }
+
     export interface StatusBarItem {
         show(): void
         hide(): void
@@ -150,6 +156,7 @@ declare namespace Oni {
             configuration: Configuration
             diagnostics: Diagnostics.Api
             editor: Editor
+            process: Process
             statusBar: StatusBar
 
             registerLanguageService(languageType: string, languageService: LanguageService)

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -1,3 +1,4 @@
+import * as ChildProcess from "child_process"
 import { EventEmitter } from "events"
 
 import * as types from "vscode-languageserver-types"
@@ -31,9 +32,9 @@ declare namespace Oni {
     }
 
     export interface Process {
-        execNodeScript(scriptPath: string, args: string[], options: ChildProcess.ExecOptions, callback: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess
-        spawnNodeScript(scriptPath: string, args: string[], options: ChildProcess.SpawnOptions): ChildProcess.ChildProcess
-        spawnProcess(startCommand: string, args: string[], options: ChildProcess.SpawnOptions): ChildProcess.ChildProcess
+        execNodeScript(scriptPath: string, args?: string[], options?: ChildProcess.ExecOptions, callback?: (err: any, stdout: string, stderr: string) => void): ChildProcess.ChildProcess
+        spawnNodeScript(scriptPath: string, args?: string[], options?: ChildProcess.SpawnOptions): ChildProcess.ChildProcess
+        spawnProcess(startCommand: string, args?: string[], options?: ChildProcess.SpawnOptions): ChildProcess.ChildProcess
     }
 
     export interface StatusBarItem {

--- a/vim/core/oni-plugin-tslint/lib/index.js
+++ b/vim/core/oni-plugin-tslint/lib/index.js
@@ -112,7 +112,7 @@ const activate = (Oni) => {
         processArgs = processArgs.concat(["--config", configPath])
         processArgs = processArgs.concat(args)
 
-        return Q.nfcall(Oni.execNodeScript, tslintPath, processArgs, { cwd: workingDirectory })
+        return Q.nfcall(Oni.process.execNodeScript, tslintPath, processArgs, { cwd: workingDirectory })
             .then((stdout, stderr) => {
 
                 const errorOutput = stdout.join(os.EOL).trim()

--- a/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
+++ b/vim/core/oni-plugin-typescript/src/TypeScriptServerHost.ts
@@ -39,7 +39,7 @@ export class TypeScriptServerHost extends events.EventEmitter {
         // This has some info on using eventPort: https://github.com/Microsoft/TypeScript/blob/master/src/server/server.ts
         // which might be more reliable
         // Can create the port using this here: https://github.com/Microsoft/TypeScript/blob/master/src/server/server.ts
-        this._tssProcess = Oni.spawnNodeScript(tssPath)
+        this._tssProcess = Oni.process.spawnNodeScript(tssPath)
         console.log("Process ID: " + this._tssProcess.pid) // tslint:disable-line no-console
 
         this._rl = readline.createInterface({


### PR DESCRIPTION
__Issue:__ There are some differences in the `PATH` settings sent to Oni, depending on how it was launched (terminal, dock, etc), and depending on the platform. Some of the language server processes (and other extensibility points) depend on having some common binaries, like node or python accessible.

__Defect:__ There isn't a guarantee that we will get all the necessary paths from the environment Oni is opened from.

__Fix:__ Add a setting that allows additional `PATH`s to be added to Oni - regardless of where it is executed.