### PR TITLE
Use pre for white-space in quickinfo

### DIFF
--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -18,6 +18,7 @@
         .title {
             width: 100%;
             margin: 8px;
+            white-space: pre;
         }
 
         .documentation {
@@ -25,6 +26,7 @@
             padding: 8px;
             color: @text-color-detail;
             font-size: @font-size-small;
+            min-width: 300px;
             max-height: 48px;
             overflow-y: auto;
         }


### PR DESCRIPTION
Partially solves #562.

I went with `pre` instead of `nowrap` because of this:


## Using `nowrap`
<img width="850" alt="screen shot 2017-08-03 at 9 52 33 am" src="https://user-images.githubusercontent.com/230476/28933586-734e67d4-7832-11e7-9296-5950ec7062d0.png">

## Using `pre`
<img width="842" alt="screen shot 2017-08-03 at 9 52 16 am" src="https://user-images.githubusercontent.com/230476/28933600-7e5eacb0-7832-11e7-9530-b1303f4acde4.png">

