### PR TITLE
Add basic bookmark support

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -49,6 +49,9 @@ export interface IConfigValues {
     // glob pattern of files to exclude from fuzzy finder (Ctrl-P)
     "oni.exclude": string[]
 
+    // bookmarks to open if opened in install dir
+    "oni.bookmarks": string[]
+
     // Editor settings
 
     "editor.backgroundOpacity": number
@@ -121,6 +124,7 @@ export class Config extends EventEmitter {
         "oni.hideMenu": false,
 
         "oni.exclude": ["**/node_modules/**"],
+        "oni.bookmarks": [],
 
         "editor.backgroundOpacity": 1.0,
         "editor.backgroundImageUrl": null,

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -31,6 +31,11 @@ export interface INeovimInstance {
     callFunction(functionName: string, args: any[]): Promise<any>
 
     /**
+     * Change the working directory of Neovim
+     */
+    chdir(directoryPath: string): Promise<any>
+
+    /**
      * Execute a VimL command
      */
     command(command: string): Promise<any>
@@ -90,6 +95,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
         this._quickFix = new QuickFixList(this)
+    }
+
+    public async chdir(directoryPath: string): Promise<void> {
+        await this.command(`cd! ${directoryPath}`)
     }
 
     public start(filesToOpen?: string[]): void {
@@ -408,3 +417,4 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         })
     }
 }
+


### PR DESCRIPTION
# 'Fixes' #506 - Fuzzy files not changing to current directory
Whenever you open Oni from the menu or clicking on the icon, it can
cause the fuzzy finder to try to find through-out the install directory,
which made Oni unusable and have to crash it or kill it via task manager
or kill -9 on linux, etc.
This checks if you are in the install directory, if so then open
bookmarks instead of searching through files.

- Implement oni.bookmarks so user can set these.
- Comment some sections of the code I have concerns about.
- Add different icon type for bookmarks.
- If bookmark change directory of vim to the bookmark
  (which triggers DirChanged so also Oni.)

##### TODO: Before adding more bookmark support it really needs to wait until we have an "Open Folder" #566 solution,so that we know how to better handle bookmarks and how to combine that with opening folders, but maybe having a key combo always to be able to open bookmarks (this would effect opening folders too?).