### PR TITLE
Add 'Open Folder' menu option + change directory

### DIFF
--- a/Menu.js
+++ b/Menu.js
@@ -4,7 +4,6 @@ const os = require('os')
 // Module to control application life.
 const { Menu, app, shell, dialog } = electron;
 
-
 const buildMenu = (mainWindow, loadInit) => {
     let menu = []
 
@@ -54,6 +53,12 @@ const buildMenu = (mainWindow, loadInit) => {
                     dialog.showOpenDialog(mainWindow, ['openFile'], (files) => {
                         executeVimCommandForFiles(":e", files)
                     })
+                }
+            },
+            {
+                label: 'Open Folder...',
+                click: (item, focusedWindow) => {
+                    executeOniCommand("oni.openFolder")
                 }
             },
             {

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -392,11 +392,6 @@ export class NeovimEditor implements IEditor {
             this._neovimInstance.getBufferIds()
                 .then((ids) => UI.Actions.setCurrentBuffers(ids))
         }
-
-        if (eventName === "DirChanged") {
-            this._neovimInstance.getCurrentWorkingDirectory()
-                .then((newDirectory) => process.chdir(newDirectory))
-        }
     }
 
     private _onConfigChanged(): void {

--- a/browser/src/Plugins/Api/Commands.ts
+++ b/browser/src/Plugins/Api/Commands.ts
@@ -4,6 +4,8 @@
  * Implementation of command registration / callback for plugins
  */
 
+import { IPluginChannel } from "./Channel"
+
 interface ICommandCallback {
     (args?: any): void
 }
@@ -12,8 +14,9 @@ interface ICommandCallback {
  * API instance for interacting with Oni (and vim)
  */
 export class Commands {
-
     private _commandToCallback: { [command: string]: ICommandCallback } = { }
+
+    constructor(private _channel: IPluginChannel) { }
 
     public registerCommand(commandName: string, callback: ICommandCallback): void {
         this._commandToCallback[commandName] = callback
@@ -28,5 +31,12 @@ export class Commands {
          }
 
          command(args)
+    }
+
+    public executeCommand(commandName: string, args?: any) {
+        this._channel.send("execute-command", null, {
+            commandName,
+            args,
+        })
     }
 }

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -83,7 +83,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         this._diagnostics = new Diagnostics(this._channel)
         this._dependencies = new Dependencies()
         this._editor = new Editor(this._channel)
-        this._commands = new Commands()
+        this._commands = new Commands(this._channel)
         this._statusBar = new StatusBar(this._channel)
         this._ui = new Ui(react)
         this._services = new Services()

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -150,6 +150,8 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
                 this.emit("buffer-enter", arg.payload.context)
             } else if (arg.payload.name === "BufLeave") {
                 this.emit("buffer-leave", arg.payload.context)
+            } else if (arg.payload.name === "DirChanged") {
+                this.emit("directory-changed", arg.payload.context)
             }
 
             this.emit(arg.payload.name, arg.payload.context)

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -150,8 +150,6 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
                 this.emit("buffer-enter", arg.payload.context)
             } else if (arg.payload.name === "BufLeave") {
                 this.emit("buffer-leave", arg.payload.context)
-            } else if (arg.payload.name === "DirChanged") {
-                this.emit("directory-changed", arg.payload.context)
             }
 
             this.emit(arg.payload.name, arg.payload.context)

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -90,6 +90,10 @@ export class PluginManager extends EventEmitter {
             this._onModeChanged(newMode)
         })
 
+        this._neovimInstance.on("directory-changed", (newDirectory: string) => {
+            this._onWorkingDirectoryChanged(newDirectory)
+        })
+
         const allPlugins = this._getAllPluginPaths()
         this._plugins = allPlugins.map((pluginRootDirectory) => this._createPlugin(pluginRootDirectory))
 
@@ -240,6 +244,17 @@ export class PluginManager extends EventEmitter {
         }
     }
 
+    private _onWorkingDirectoryChanged(newDirectory: string): void {
+        const filetype = this._lastEventContext ? this._lastEventContext.filetype : ""
+
+        this._channel.host.send({
+            type: "event",
+            payload: {
+                name: "directory-changed",
+                context: newDirectory,
+            },
+        }, Capabilities.createPluginFilter(filetype))
+    }
     private _onModeChanged(newMode: string): void {
         const filetype = this._lastEventContext ? this._lastEventContext.filetype : ""
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -207,6 +207,9 @@ export class PluginManager extends EventEmitter {
             case "set-errors":
                 this.emit("set-errors", pluginResponse.payload.key, pluginResponse.payload.fileName, pluginResponse.payload.errors)
                 break
+            case "execute-command":
+                this._commandManager.executeCommand(pluginResponse.payload.commandName, pluginResponse.payload.args)
+                break
             case "find-all-references":
                 this.emit("find-all-references", pluginResponse.payload.references)
                 break

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -79,7 +79,6 @@ const openFolder = (neovimInstance: INeovimInstance) => {
         }
 
         const folderToOpen = folder[0]
-
         neovimInstance.chdir(folderToOpen)
     })
 }

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -58,9 +58,28 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
                             "Show all logs in the bottom panel",
                             () => UI.Actions.changeLogsVisibility(true)),
 
+        new CallbackCommand("oni.openFolder", "Open Folder", "", () => openFolder(neovimInstance)),
+
         // Add additional commands here
         // ...
     ]
 
     commands.forEach((c) => commandManager.registerCommand(c))
+}
+
+const openFolder = (neovimInstance: INeovimInstance) => {
+    const dialogOptions: any = {
+        title: "Open Folder",
+        properties: ["openDirectory"],
+    }
+
+    remote.dialog.showOpenDialog(remote.getCurrentWindow(), dialogOptions, (folder: string[]) => {
+        if (!folder || !folder[0]) {
+            return
+        }
+
+        const folderToOpen = folder[0]
+
+        neovimInstance.chdir(folderToOpen)
+    })
 }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -31,6 +31,11 @@ export interface INeovimInstance {
     callFunction(functionName: string, args: any[]): Promise<any>
 
     /**
+     * Change the working directory of Neovim
+     */
+    chdir(directoryPath: string): Promise<any>
+
+    /**
      * Execute a VimL command
      */
     command(command: string): Promise<any>
@@ -90,6 +95,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this._lastWidthInPixels = widthInPixels
         this._lastHeightInPixels = heightInPixels
         this._quickFix = new QuickFixList(this)
+    }
+
+    public async chdir(directoryPath: string): Promise<void> {
+        await this.command(`cd ${directoryPath}`)
     }
 
     public start(filesToOpen?: string[]): void {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -425,7 +425,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     private async _updateProcessDirectory(): Promise<void> {
         const newDirectory = await this.getCurrentWorkingDirectory()
         process.chdir(newDirectory)
-        this.emit("event", "directory-changed", newDirectory)
+        this.emit("directory-changed", newDirectory)
     }
 
 }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -98,7 +98,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     public async chdir(directoryPath: string): Promise<void> {
-        await this.command(`cd ${directoryPath}`)
+        await this.command(`cd! ${directoryPath}`)
     }
 
     public start(filesToOpen?: string[]): void {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -139,7 +139,12 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                             const eventName = args[0][0]
                             const eventContext = args[0][1]
 
+                            if (eventName === "DirChanged") {
+                                this._updateProcessDirectory()
+                            }
+
                             this.emit("event", eventName, eventContext)
+
                         } else if (pluginMethod === "incremental_buffer_update") {
                             const eventContext = args[0][0]
                             const bufferLine = args[0][1]
@@ -416,4 +421,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             }
         })
     }
+
+    private async _updateProcessDirectory(): Promise<void> {
+        const newDirectory = await this.getCurrentWorkingDirectory()
+        process.chdir(newDirectory)
+        this.emit("event", "directory-changed", newDirectory)
+    }
+
 }

--- a/vim/core/oni-core-statusbar/index.js
+++ b/vim/core/oni-core-statusbar/index.js
@@ -5,7 +5,7 @@ const rgb = (r, g, b) => `rgb(${r}, ${g}, ${b})`
 const activate = (Oni) => {
     const React = Oni.dependencies.React
 
-    const filePathItem = Oni.statusBar.createItem(0, -1, "oni.status.filePath")
+    const workingDirectoryItem = Oni.statusBar.createItem(0, -1, "oni.status.workingDirectory")
     const fileTypeItem = Oni.statusBar.createItem(0, 0, "oni.status.fileType")
     const lineNumberItem = Oni.statusBar.createItem(1, -1, "oni.status.lineNumber")
     const modeItem = Oni.statusBar.createItem(1, -2, "oni.status.mode")
@@ -53,15 +53,17 @@ const activate = (Oni) => {
         lineNumberItem.setContents(element)
     }
 
-    const setFilePath = (filePath) => {
-        let filePathString = filePath
-        if (!filePathString) {
-            filePathString = "[No Name]"
+    const setWorkingDirectory = (workingDirectory) => {
+        if (!workingDirectory) {
+            workingDirectory = ""
         }
 
-        const element = React.createElement("div", { style: { color: "rgb(140, 140, 140)" } }, filePathString)
+        const openFolderCommand = () => {
+            Oni.commands.executeCommand("oni.openFolder")
+        }
 
-        filePathItem.setContents(element)
+        const element = React.createElement("div", { style: { color: "rgb(140, 140, 140)" }, onClick: openFolderCommand }, workingDirectory)
+        workingDirectoryItem.setContents(element)
     }
 
     const setFileType = (fileType) => {
@@ -98,17 +100,20 @@ const activate = (Oni) => {
 
     Oni.on("buffer-enter", (evt) => {
         setFileType(evt.filetype)
-        setFilePath(evt.bufferFullPath)
+    })
+
+    Oni.on("directory-changed", (newDirectory) => {
+        setWorkingDirectory(newDirectory)
     })
 
     setMode("normal")
     setLineNumber(1, 1)
-    setFilePath(null)
-    setFileType(null)
+    setWorkingDirectory(null)
+    setWorkingDirectory(process.cwd())
 
     modeItem.show()
     lineNumberItem.show()
-    filePathItem.show()
+    workingDirectoryItem.show()
 }
 
 module.exports = {


### PR DESCRIPTION
This is just some scaffolding for #566 and is to help understand the sort of functionality users might want with the `Open Folder` option.

This change:
- adds the `Open Folder` option to the menu
- changes the working directory to the selected folder (which means QuickOpen is now relative to that folder)