### PR TITLE
Fix #575 (FocusGained / FocusLost functionality)

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -9,7 +9,7 @@ import * as ReactDOM from "react-dom"
 
 import * as types from "vscode-languageserver-types"
 
-import { ipcRenderer } from "electron"
+import { ipcRenderer, remote } from "electron"
 
 import { IncrementalDeltaRegionTracker } from "./../DeltaRegionTracker"
 import { NeovimInstance } from "./../neovim"
@@ -220,6 +220,16 @@ export class NeovimEditor implements IEditor {
         })
 
         this._render()
+
+        const browserWindow = remote.getCurrentWindow()
+
+        browserWindow.on("blur", () => {
+            this._neovimInstance.executeAutoCommand("FocusLost")
+        })
+
+        browserWindow.on("focus", () => {
+            this._neovimInstance.executeAutoCommand("FocusGained")
+        })
 
         this._onConfigChanged()
         this._config.registerListener(() => this._onConfigChanged())

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -50,6 +50,8 @@ const start = (args: string[]) => {
 
     let prevConfigValues = config.getValues()
 
+    const browserWindow = remote.getCurrentWindow()
+
     const configChange = () => {
         let newConfigValues = config.getValues()
         let prop: keyof Config.IConfigValues
@@ -64,10 +66,9 @@ const start = (args: string[]) => {
         document.body.style.fontSize = config.getValue("editor.fontSize")
         document.body.style.fontVariant = config.getValue("editor.fontLigatures") ? "normal" : "none"
 
-        const window = remote.getCurrentWindow()
         const hideMenu: boolean = config.getValue("oni.hideMenu")
-        window.setAutoHideMenuBar(hideMenu)
-        window.setMenuBarVisibility(!hideMenu)
+        browserWindow.setAutoHideMenuBar(hideMenu)
+        browserWindow.setMenuBarVisibility(!hideMenu)
 
         const loadInit: boolean = config.getValue("oni.loadInitVim")
         if (loadInit !== loadInitVim) {
@@ -76,7 +77,7 @@ const start = (args: string[]) => {
             loadInitVim = loadInit
         }
 
-        window.setFullScreen(config.getValue("editor.fullScreenOnStart"))
+        browserWindow.setFullScreen(config.getValue("editor.fullScreenOnStart"))
     }
 
     configChange() // initialize values

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -58,6 +58,8 @@ export interface INeovimInstance {
     getCursorRow(): Promise<number>
 
     open(fileName: string): Promise<void>
+
+    executeAutoCommand(autoCommand: string): Promise<void>
 }
 
 /**
@@ -99,6 +101,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     public async chdir(directoryPath: string): Promise<void> {
         await this.command(`cd! ${directoryPath}`)
+    }
+
+    public async executeAutoCommand(autoCommand: string): Promise<void> {
+        await this.command(`doautocmd <nomodeline> ${autoCommand}`)
     }
 
     public start(filesToOpen?: string[]): void {

--- a/main.js
+++ b/main.js
@@ -85,7 +85,7 @@ function createWindow(commandLineArguments, workingDirectory) {
     mainWindow.loadURL(`file://${__dirname}/index.html`)
 
     // Open the DevTools.
-    if (process.env.NODE_ENV === "development")
+    if (process.env.NODE_ENV === "development" || commandLineArguments.indexOf("--debug") >= 0)
         mainWindow.webContents.openDevTools()
 
     // Emitted when the window is closed.


### PR DESCRIPTION
- Listen to `BrowserWindow`'s `blur` and `focus` events
- Add an `executeAutoCommand` method to `NeovimInstance`
- Call `executeAutoCommand` on `blur`/`focus`

Fixes #575 