### PR TITLE
Fix #580: Include 'set mouse=a' as a default configuration value.

### DIFF
--- a/vim/default/bundle/oni-vim-defaults/plugin/init.vim
+++ b/vim/default/bundle/oni-vim-defaults/plugin/init.vim
@@ -17,6 +17,9 @@ set noruler
 set laststatus=0
 set noshowcmd
 
+" Enable GUI mouse behavior
+set mouse=a
+
 set list
 set listchars=trail:·
 


### PR DESCRIPTION
- Fixes #580 