### PR TITLE
Fixes #579 - Backwards Compatibility for Neovim Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Oni features a buffer tab bar, like many common IDEs. VIM has its own definition
 ##### Options
 
 - `tabs.enabled` - If set to `true`, the tabs are visible. (Default: `true`)
-- `tabs.showVimTabs` - If set to `true`, shows vim tabs. Otherwise, shows open buffers. (Default: `false`)
+- `tabs.showVimTabs` - If set to `true`, shows vim tabs. Otherwise, shows open buffers. (Default: `false`. Requires Neovim 0.2.1+)
 
 ### Languages
 

--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -157,7 +157,7 @@ export class Config extends EventEmitter {
         "statusbar.fontSize": "12px",
 
         "tabs.enabled": true,
-        "tabs.showVimTabs": true,
+        "tabs.showVimTabs": false,
     }
 
     private MacConfig: Partial<IConfigValues> = {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -65,6 +65,7 @@ export interface INeovimInstance {
 export interface INeovimApiVersion {
     major: number
     minor: number
+    patch: number
 }
 
 /**
@@ -208,19 +209,19 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private async _attachUI(columns: number, rows: number): Promise<void> {
         const version = await this.getApiVersion()
-        const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor)
+        const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor, version.patch)
 
         await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])
     }
 
-    private _getStartupOptionsForVersion(major: number, minor: number) {
-        if (major >= 0 && minor >= 2) {
+    private _getStartupOptionsForVersion(major: number, minor: number, patch: number) {
+        if (major >= 0 && minor >= 2 && patch >= 1) {
             return {
                 rgb: true,
                 popupmenu_external: true,
                 ext_tabline: true,
             }
-        } else if (major === 0 && minor === 1) {
+        } else if (major === 0 && minor === 2) {
             // 0.1 and below does not support external tabline
             // See #579 for more info on the manifestation.
             return {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -436,7 +436,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private async _attachUI(columns: number, rows: number): Promise<void> {
         const version = await this.getApiVersion()
-        console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console-log
+        console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console
 
         const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor, version.patch)
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -57,7 +57,14 @@ export interface INeovimInstance {
     getCursorColumn(): Promise<number>
     getCursorRow(): Promise<number>
 
+    getApiVersion(): Promise<INeovimApiVersion>
+
     open(fileName: string): Promise<void>
+}
+
+export interface INeovimApiVersion {
+    major: number
+    minor: number
 }
 
 /**
@@ -175,21 +182,13 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                     remote.getCurrentWindow().close()
                 })
 
-                const startupOptions = {
-                    rgb: true,
-                    popupmenu_external: true,
-                    ext_tabline: true,
-                }
-
                 const size = this._getSize()
                 this._rows = size.rows
                 this._cols = size.cols
 
                 // Workaround for bug in neovim/node-client
                 // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
-                return this._neovim.request("nvim_get_api_info", [])
-                    .then((info) => { debugger })
-                    .then(() => this._neovim.request("nvim_ui_attach", [size.cols, size.rows, startupOptions]))
+                return this._attachUI(size.cols, size.rows)
                     .then(() => {
                         this.emit("logInfo", "Attach success")
 
@@ -207,6 +206,32 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             })
     }
 
+    private async _attachUI(columns: number, rows: number): Promise<void> {
+        const version = await this.getApiVersion()
+        const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor)
+
+        await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])
+    }
+
+    private _getStartupOptionsForVersion(major: number, minor: number) {
+        if (major >= 0 && minor >= 2) {
+            return {
+                rgb: true,
+                popupmenu_external: true,
+                ext_tabline: true,
+            }
+        } else if (major === 0 && minor === 1) {
+            // 0.1 and below does not support external tabline
+            // See #579 for more info on the manifestation.
+            return {
+                rgb: true,
+                popupmenu_external: true,
+            }
+        } else {
+            throw "Unsupported version of Neovim."
+        }
+    }
+
     public getMode(): Promise<string> {
         return this.eval<string>("mode()")
     }
@@ -218,8 +243,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         return this.eval<number>("col('.')")
     }
 
-    /**
-     * Returns the current cursor row in buffer-space
+    /** Returns the current cursor row in buffer-space
      */
     public getCursorRow(): Promise<number> {
         return this.eval<number>("line('.')")
@@ -302,6 +326,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         const size = this._getSize()
 
         this._resizeInternal(size.rows, size.cols)
+    }
+
+    public async getApiVersion(): Promise<INeovimApiVersion> {
+        const versionInfo = await this._neovim.request("nvim_get_api_info", [])
+        return <any>versionInfo[1].version
     }
 
     private _resizeInternal(rows: number, columns: number): void {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -187,7 +187,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
                 // Workaround for bug in neovim/node-client
                 // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
-                return this._neovim.request("nvim_ui_attach", [size.cols, size.rows, startupOptions])
+                return this._neovim.request("nvim_get_api_info", [])
+                    .then((info) => { debugger })
+                    .then(() => this._neovim.request("nvim_ui_attach", [size.cols, size.rows, startupOptions]))
                     .then(() => {
                         this.emit("logInfo", "Attach success")
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -209,6 +209,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private async _attachUI(columns: number, rows: number): Promise<void> {
         const version = await this.getApiVersion()
+        console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`)
+
         const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor, version.patch)
 
         await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -207,34 +207,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             })
     }
 
-    private async _attachUI(columns: number, rows: number): Promise<void> {
-        const version = await this.getApiVersion()
-        console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`)
-
-        const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor, version.patch)
-
-        await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])
-    }
-
-    private _getStartupOptionsForVersion(major: number, minor: number, patch: number) {
-        if (major >= 0 && minor >= 2 && patch >= 1) {
-            return {
-                rgb: true,
-                popupmenu_external: true,
-                ext_tabline: true,
-            }
-        } else if (major === 0 && minor === 2) {
-            // 0.1 and below does not support external tabline
-            // See #579 for more info on the manifestation.
-            return {
-                rgb: true,
-                popupmenu_external: true,
-            }
-        } else {
-            throw "Unsupported version of Neovim."
-        }
-    }
-
     public getMode(): Promise<string> {
         return this.eval<string>("mode()")
     }
@@ -462,4 +434,31 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         this.emit("directory-changed", newDirectory)
     }
 
+    private async _attachUI(columns: number, rows: number): Promise<void> {
+        const version = await this.getApiVersion()
+        console.log(`Neovim version reported as ${version.major}.${version.minor}.${version.patch}`) // tslint:disable-line no-console-log
+
+        const startupOptions = this._getStartupOptionsForVersion(version.major, version.minor, version.patch)
+
+        await this._neovim.request("nvim_ui_attach", [columns, rows, startupOptions])
+    }
+
+    private _getStartupOptionsForVersion(major: number, minor: number, patch: number) {
+        if (major >= 0 && minor >= 2 && patch >= 1) {
+            return {
+                rgb: true,
+                popupmenu_external: true,
+                ext_tabline: true,
+            }
+        } else if (major === 0 && minor === 2) {
+            // 0.1 and below does not support external tabline
+            // See #579 for more info on the manifestation.
+            return {
+                rgb: true,
+                popupmenu_external: true,
+            }
+        } else {
+            throw "Unsupported version of Neovim."
+        }
+    }
 }


### PR DESCRIPTION
__Issue:__ The tabline feature, to integrate with vim tabs, uses the `external_tabline` parameter for attaching to UI. If we try and pass that to an earlier version of Neovim, the attach will fail.

__Defect:__ We weren't caring about the version or level of API support for the API instance.

__Fix:__ Query Neovim for the version, and decide what startup options to send it based on the version.

Longer-term, it would be nice to refactor this in a cleaner way, so that there isn't a giant mess of if / switch statements. In addition, there might be other cases we need to handle backwards compatibility, aside from the `startupOptions` parameter.

Fixes #579 (at least on my Linux machine, running 0.2.0-dev neovim).