### PR TITLE
Performance: Convert remainder of React components to 'PureComponent'

### DIFF
--- a/browser/src/UI/Icon.tsx
+++ b/browser/src/UI/Icon.tsx
@@ -22,7 +22,7 @@ export interface IconProps {
     className?: string
 }
 
-export class Icon extends React.Component<IconProps, void> {
+export class Icon extends React.PureComponent<IconProps, void> {
     public render(): JSX.Element {
 
         const className = "fa fa-" + this.props.name + " " + this._getClassForIconSize(this.props.size as any) // FIXME: undefined

--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -12,7 +12,7 @@ interface IRootComponentProps {
     editor: IEditor
 }
 
-export class RootComponent extends React.Component<IRootComponentProps, void> {
+export class RootComponent extends React.PureComponent<IRootComponentProps, void> {
     public render() {
         return <div className="stack disable-mouse">
             <div className="stack">

--- a/browser/src/UI/TestComponent.tsx
+++ b/browser/src/UI/TestComponent.tsx
@@ -1,7 +1,0 @@
-import * as React from "react"
-
-export class TestComponent extends React.Component<void, void> {
-    public render() {
-        return <div>hey</div>
-    }
-}

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -83,7 +83,7 @@ export interface IAutoCompletionItemProps extends Oni.Plugin.CompletionInfo {
     isSelected: boolean
 }
 
-export class AutoCompletionItem extends React.Component<IAutoCompletionItemProps, void> {
+export class AutoCompletionItem extends React.PureComponent<IAutoCompletionItemProps, void> {
     public render(): JSX.Element {
 
         let className = "entry"
@@ -132,7 +132,7 @@ export interface IAutoCompletionIconProps {
     kind: types.CompletionItemKind
 }
 
-export class AutoCompletionIcon extends React.Component<IAutoCompletionIconProps, void> {
+export class AutoCompletionIcon extends React.PureComponent<IAutoCompletionIconProps, void> {
 
     public render(): JSX.Element {
 

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -10,7 +10,7 @@ export interface IBackgroundProps {
     backgroundOpacity: number
 }
 
-export class BackgroundRenderer extends React.Component<IBackgroundProps, void> {
+export class BackgroundRenderer extends React.PureComponent<IBackgroundProps, void> {
     public render(): JSX.Element {
         const imageStyle = {
             backgroundImage: "url(" + this.props.backgroundImageUrl + ")",

--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -18,7 +18,7 @@ export interface ICursorProps {
 
 require("./Cursor.less") // tslint:disable-line no-var-requires
 
-class CursorRenderer extends React.Component<ICursorProps, void> {
+class CursorRenderer extends React.PureComponent<ICursorProps, void> {
 
     public render(): JSX.Element {
 

--- a/browser/src/UI/components/EditorHost.tsx
+++ b/browser/src/UI/components/EditorHost.tsx
@@ -12,7 +12,7 @@ export interface IEditorHostProps {
     editor: IEditor
 }
 
-export class EditorHost extends React.Component<IEditorHostProps, void> {
+export class EditorHost extends React.PureComponent<IEditorHostProps, void> {
 
     public render(): JSX.Element {
         return <div className="container vertical full">

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -97,7 +97,7 @@ export interface IErrorMarkerProps {
     showDetails: boolean
 }
 
-export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
+export class ErrorMarker extends React.PureComponent<IErrorMarkerProps, void> {
 
     private config = Config.instance()
 
@@ -149,7 +149,7 @@ export interface IErrorSquiggleProps {
     color: string,
 }
 
-export class ErrorSquiggle extends React.Component<IErrorSquiggleProps, void> {
+export class ErrorSquiggle extends React.PureComponent<IErrorSquiggleProps, void> {
     public render(): JSX.Element {
 
         const { x, y, width, height, color } = this.props

--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -7,7 +7,7 @@ export interface IHighlightTextProps {
     className: string
 }
 
-export class HighlightText extends React.Component<IHighlightTextProps, void> {
+export class HighlightText extends React.PureComponent<IHighlightTextProps, void> {
 
     public render(): JSX.Element {
 
@@ -38,7 +38,7 @@ export interface IHighlightTextByIndexProps {
     className: string
 }
 
-export class HighlightTextByIndex extends React.Component<IHighlightTextByIndexProps, void> {
+export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIndexProps, void> {
     public render(): JSX.Element {
 
         const childNodes: JSX.Element[] = []

--- a/browser/src/UI/components/Logs.tsx
+++ b/browser/src/UI/components/Logs.tsx
@@ -21,7 +21,7 @@ export interface ILogsProps {
     hide: () => void
 }
 
-export class LogsRenderer extends React.Component<ILogsProps, void> {
+export class LogsRenderer extends React.PureComponent<ILogsProps, void> {
     public render(): JSX.Element {
         // TODO copy details to clipboard
         if (!this.props.visible) { return null }

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -121,7 +121,7 @@ export interface IMenuItemProps {
     onClick: Function
 }
 
-export class MenuItem extends React.Component<IMenuItemProps, void> {
+export class MenuItem extends React.PureComponent<IMenuItemProps, void> {
 
     public render(): JSX.Element {
         let className = "item"

--- a/browser/src/UI/components/Message.tsx
+++ b/browser/src/UI/components/Message.tsx
@@ -19,7 +19,7 @@ require("./Message.less") // tslint:disable-line no-var-requires
 //     items: string[]
 // }
 
-export class Message extends React.Component<void, void> {
+export class Message extends React.PureComponent<void, void> {
 
     public render(): null | JSX.Element {
         return <Visible visible={true}>

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -60,7 +60,7 @@ export interface ITextProps {
     text: string
 }
 
-export class TextComponent extends React.Component<ITextProps, void> {
+export class TextComponent extends React.PureComponent<ITextProps, void> {
 
 }
 

--- a/browser/src/UI/components/Visible.tsx
+++ b/browser/src/UI/components/Visible.tsx
@@ -4,7 +4,7 @@ export interface IVisibleProps {
     visible: boolean
 }
 
-export class Visible extends React.Component<IVisibleProps, void> {
+export class Visible extends React.PureComponent<IVisibleProps, void> {
 
     public render(): null | JSX.Element {
         if (this.props.visible) {


### PR DESCRIPTION
- Missed several components in the performance work, this moves the remainder of components to use `React.PureComponent`. This has a significant performance gain by preventing unnecessary re-renders of the React components.