### PR TITLE
Bundle Size: Reduce lodash dependency, taking bundle.js from 1.9MB to 1.5MB

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from "events"
 
 import * as fs from "fs"
-import * as _ from "lodash"
+import * as cloneDeep from "lodash/cloneDeep"
+import * as isError from "lodash/isError"
 import * as path from "path"
 
 import * as Performance from "./Performance"
@@ -226,7 +227,7 @@ export class Config extends EventEmitter {
     }
 
     public getValues(): IConfigValues {
-        return _.cloneDeep(this.Config)
+        return cloneDeep(this.Config)
     }
 
     public getUserFolder(): string {
@@ -244,12 +245,12 @@ export class Config extends EventEmitter {
     // so we can't emit the parsing error to anyone when it happens
     public getParsingError(): Error | null {
         const maybeError = this.getUserRuntimeConfig()
-        return _.isError(maybeError) ? maybeError : null
+        return isError(maybeError) ? maybeError : null
     }
 
     private applyConfig(): void {
         let userRuntimeConfigOrError = this.getUserRuntimeConfig()
-        if (_.isError(userRuntimeConfigOrError)) {
+        if (isError(userRuntimeConfigOrError)) {
             this.emit("logError", userRuntimeConfigOrError)
             this.Config = { ...this.DefaultConfig, ...this.DefaultPlatformConfig}
         } else {

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -7,7 +7,7 @@
 
 import * as os from "os"
 
-import * as _ from "lodash"
+import * as isEqual from "lodash/isEqual"
 import * as rpc from "vscode-jsonrpc"
 import * as types from "vscode-languageserver-types"
 
@@ -102,7 +102,7 @@ export class LanguageClient {
                             return this.start(newParams)
                         }
 
-                        if (!_.isEqual(this._initializationParams, newParams)) {
+                        if (!isEqual(this._initializationParams, newParams)) {
                             this._initializationParams = newParams
 
                             return this.end()

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClientHelpers.ts
@@ -4,7 +4,7 @@
 
 import * as os from "os"
 
-import * as _ from "lodash"
+import * as flatMap from "lodash/flatMap"
 import * as types from "vscode-languageserver-types"
 
 export const ProtocolConstants = {
@@ -60,7 +60,7 @@ export const unwrapFileUriPath = (uri: string) => decodeURIComponent((uri).split
 
 export const getTextFromContents = (contents: types.MarkedString | types.MarkedString[]): string[] => {
     if (contents instanceof Array) {
-        return _.flatMap(contents, (markedString) => getTextFromMarkedString(markedString))
+        return flatMap(contents, (markedString) => getTextFromMarkedString(markedString))
     } else {
         return getTextFromMarkedString(contents)
     }

--- a/browser/src/Plugins/PackageMetadataParser.ts
+++ b/browser/src/Plugins/PackageMetadataParser.ts
@@ -4,7 +4,7 @@
  * Responsible for parsing and normalizing package.json for ONI plugins
  */
 
-import * as _ from "lodash"
+import * as keys from "lodash/keys"
 
 import * as Capabilities from "./Api/Capabilities"
 
@@ -42,7 +42,7 @@ export const getAllCommandsFromMetadata = (metadata: Capabilities.IPluginMetadat
         return []
     }
 
-    const commandNames = _.keys(commands)
+    const commandNames = keys(commands)
     return commandNames.map((command) => ({
         command,
         name: commands[command].name,

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -4,7 +4,7 @@
  * Manages Oni commands. These commands show up in the command palette, and are exposed to plugins.
  */
 
-import * as _ from "lodash"
+import * as values from "lodash/values"
 
 import { INeovimInstance } from "./../neovim"
 
@@ -66,7 +66,7 @@ export class CommandManager implements ITaskProvider {
     }
 
     public getTasks(): Promise<ITask[]> {
-        const commands = _.values(this._commandDictionary)
+        const commands = values(this._commandDictionary)
         const tasks = commands.map((c) => ({
             name: c.name,
             detail: c.detail,

--- a/browser/src/Services/Errors.ts
+++ b/browser/src/Services/Errors.ts
@@ -1,4 +1,5 @@
-import * as _ from "lodash"
+import * as flatten from "lodash/flatten"
+import * as keys from "lodash/keys"
 
 import { INeovimInstance } from "./../neovim"
 
@@ -50,14 +51,14 @@ export class Errors implements ITaskProvider {
     }
 
     private _setQuickFixErrors(): void {
-        const arrayOfErrors = _.keys(this._errors).map((filename) => {
+        const arrayOfErrors = keys(this._errors).map((filename) => {
             return this._errors[filename].map((e) => ({
                 ...e,
                 filename,
             }))
         })
 
-        const flattenedErrors = _.flatten(arrayOfErrors)
+        const flattenedErrors = flatten(arrayOfErrors)
         const errors = flattenedErrors.map((e) => <any>({
             filename: e.filename,
             col: e.range.start.character || 0,

--- a/browser/src/Services/Formatter.ts
+++ b/browser/src/Services/Formatter.ts
@@ -4,7 +4,7 @@
  * Manages the quick open menu
  */
 
-import * as _ from "lodash"
+import * as orderBy from "lodash/orderBy"
 import * as Config from "./../Config"
 import { INeovimInstance } from "./../neovim"
 import { PluginManager } from "./../Plugins/PluginManager"
@@ -42,7 +42,7 @@ export class Formatter {
             // another edit referenced at column 8 would now apply at column 7.
             // Long-term, there needs to be a strategy to map / re-map edits, but for now,
             // this can be worked around by sorting the edits in reverse - applying later column edits first
-            const sortedEdits = _.orderBy(response.edits, [(e) => e.start.line, (e) => e.start.column], ["asc", "desc"])
+            const sortedEdits = orderBy(response.edits, [(e) => e.start.line, (e) => e.start.column], ["asc", "desc"])
 
             sortedEdits.forEach((edit) => {
 

--- a/browser/src/Services/QuickOpen.ts
+++ b/browser/src/Services/QuickOpen.ts
@@ -9,7 +9,7 @@ import * as path from "path"
 import * as Log from "./../Log"
 
 import * as glob from "glob"
-import * as _ from "lodash"
+import * as flatten from "lodash/flatten"
 import * as Q from "q"
 
 import * as Config from "./../Config"
@@ -70,7 +70,7 @@ export class QuickOpen {
                 if (isGit) {
                     return Q.all([Git.getTrackedFiles(), Git.getUntrackedFiles(exclude)])
                         .then((values: [string[], string[]]) => {
-                            const allFiles = _.flatten(values)
+                            const allFiles = flatten(values)
                             this._showMenuFromFiles(allFiles)
                         })
                 } else {

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -9,7 +9,8 @@
  *  - NPM tasks
  */
 
-import * as _ from "lodash"
+import * as find from "lodash/find"
+import * as flatten from "lodash/flatten"
 
 import * as Parser from "./../Parser"
 import { getProjectConfiguration } from "./../ProjectConfig"
@@ -107,7 +108,7 @@ export class Tasks {
         UI.events.on("menu-item-selected:tasks", (selectedItem: any) => {
             const {label, detail} = selectedItem.selectedOption
 
-            const selectedTask = _.find(this._lastTasks, (t) => t.name === label && t.detail === detail)
+            const selectedTask = find(this._lastTasks, (t) => t.name === label && t.detail === detail)
 
             if (selectedTask) {
                 selectedTask.callback()
@@ -148,6 +149,6 @@ export class Tasks {
 
         const allTasks = await Promise.all(taskProviders.map(async (t: ITaskProvider) => await t.getTasks() || []))
 
-        this._lastTasks = _.flatten(allTasks)
+        this._lastTasks = flatten(allTasks)
     }
 }

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -7,7 +7,9 @@ import * as Fuse from "fuse.js"
 import * as Config from "./../Config"
 import * as Actions from "./Actions"
 
-import * as _ from "lodash"
+import * as concat from "lodash/concat"
+import * as pick from "lodash/pick"
+import * as sortBy from "lodash/sortBy"
 
 import * as types from "vscode-languageserver-types"
 
@@ -105,7 +107,7 @@ export function reducer<K extends keyof Config.IConfigValues> (s: State.IState, 
                 folded: true,
             }
             return Object.assign({}, s, {
-                logs: _.concat(s.logs, newLog),
+                logs: concat(s.logs, newLog),
             })
         case "SHOW_MESSAGE_DIALOG":
             return {
@@ -211,7 +213,7 @@ export const buffersReducer = (s: State.IBufferState, a: Actions.SimpleAction): 
                 activeBufferId = null
             }
 
-            let newById = _.pick(s.byId, a.payload.bufferIds)
+            let newById = pick(s.byId, a.payload.bufferIds)
 
             return <State.IBufferState>{
                 activeBufferId,
@@ -271,7 +273,7 @@ export function popupMenuReducer (s: State.IMenu | null, a: Actions.SimpleAction
 
     switch (a.type) {
         case "SHOW_MENU":
-            const sortedOptions = _.sortBy(a.payload.options, (f) => f.pinned ? 0 : 1).map((o) => ({
+            const sortedOptions = sortBy(a.payload.options, (f) => f.pinned ? 0 : 1).map((o) => ({
                 icon: o.icon,
                 detail: o.detail,
                 label: o.label,
@@ -367,7 +369,7 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
             }
         })
 
-        return _.sortBy(opt, (o) => o.pinned ? 0 : 1)
+        return sortBy(opt, (o) => o.pinned ? 0 : 1)
     }
 
     let fuseOptions = {

--- a/browser/src/UI/Selectors.ts
+++ b/browser/src/UI/Selectors.ts
@@ -10,7 +10,7 @@ import * as State from "./State"
 
 import { Rectangle } from "./Types"
 
-import * as _ from "lodash"
+import * as flatten from "lodash/flatten"
 
 export const isPopupMenuOpen = (state: State.IState) => {
     const popupMenu = state.popupMenu
@@ -56,7 +56,7 @@ export const getAllErrorsForFile = (fileName: string, errors: State.Errors) => {
     }
 
     const arrayOfErrorsArray = Object.values(allErrorsByKey)
-    return _.flatten(arrayOfErrorsArray)
+    return flatten(arrayOfErrorsArray)
 }
 
 export const getActiveWindow = (state: State.IState): State.IWindow => {

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -2,7 +2,7 @@
  * AutoCompletion.tsx
  */
 
-import * as _ from "lodash"
+import * as take from "lodash/take"
 import * as React from "react"
 import * as types from "vscode-languageserver-types"
 
@@ -47,7 +47,7 @@ export class AutoCompletion extends React.PureComponent<IAutoCompletionProps, vo
         }
 
         // TODO: sync max display items (10) with value in Reducer.autoCompletionReducer() (Reducer.ts)
-        const firstTenEntries = _.take(this.props.entries, 10)
+        const firstTenEntries = take(this.props.entries, 10)
 
         const entries = firstTenEntries.map((s, i) => {
             const isSelected = i === this.props.selectedIndex

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import { connect } from "react-redux"
 
-import * as _ from "lodash"
+import * as take from "lodash/take"
 
 import * as ActionCreators from "./../ActionCreators"
 import * as State from "./../State"
@@ -37,7 +37,7 @@ export class Menu extends React.PureComponent<IMenuProps, void> {
         }
 
         // TODO: sync max display items (10) with value in Reducer.popupMenuReducer() (Reducer.ts)
-        const initialItems = _.take(this.props.items, 10)
+        const initialItems = take(this.props.items, 10)
 
         // const pinnedItems = initialItems.filter(f => f.pinned)
         // const unpinnedItems = initialItems.filter(f => !f.pinned)

--- a/browser/src/UI/components/Message.tsx
+++ b/browser/src/UI/components/Message.tsx
@@ -2,8 +2,6 @@ import * as React from "react"
 
 // import { connect } from "react-redux"
 
-// import * as _ from "lodash"
-
 // import * as ActionCreators from "./../ActionCreators"
 // import * as State from "./../State"
 

--- a/browser/src/UI/components/StatusBar.tsx
+++ b/browser/src/UI/components/StatusBar.tsx
@@ -1,7 +1,7 @@
 
 import * as electron from "electron"
 
-import * as _ from "lodash"
+import * as keys from "lodash/keys"
 import * as React from "react"
 
 import { connect } from "react-redux"
@@ -81,9 +81,9 @@ const getStatusBar = (state: State.IState) => state.statusBar
 const getStatusBarItems = createSelector(
     [getStatusBar],
     (statusBar) => {
-        const keys = _.keys(statusBar)
+        const statusKeys = keys(statusBar)
 
-        const statusBarItems = keys.map((k) => ({
+        const statusBarItems = statusKeys.map((k) => ({
             id: k,
             ...statusBar[k],
         }))

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -13,7 +13,7 @@ import { PluginManager } from "./Plugins/PluginManager"
 
 import { CommandManager } from "./Services/CommandManager"
 
-import * as _ from "lodash"
+import * as isEqual from "lodash/isEqual"
 
 import * as UI from "./UI/index"
 
@@ -56,7 +56,7 @@ const start = (args: string[]) => {
         let newConfigValues = config.getValues()
         let prop: keyof Config.IConfigValues
         for (prop in newConfigValues) {
-            if (!_.isEqual(newConfigValues[prop], prevConfigValues[prop])) {
+            if (!isEqual(newConfigValues[prop], prevConfigValues[prop])) {
                 UI.Actions.setConfigValue(prop, newConfigValues[prop])
             }
         }


### PR DESCRIPTION
Most of our imports were using `import * as _ from "lodash"`, which is problematic, because webpack will include the _whole lodash bundle_. Lodash is huge and accounted for almost a quarter of the bundle size - so by constraining the package to only the functions we use, the package size will be significantly reduced (which will improve the startup / load time of Oni).