### PR TITLE
Fix #596: Scrollbar not showing up due to state regression

### DIFF
--- a/browser/src/UI/Selectors.ts
+++ b/browser/src/UI/Selectors.ts
@@ -42,6 +42,17 @@ export const getAllBuffers = (buffers: State.IBufferState): State.IBuffer[] => {
     return buffers.allIds.map((id) => buffers.byId[id])
 }
 
+export const getBufferByFilename = (fileName: string, buffers: State.IBufferState): State.IBuffer => {
+    const allBuffers = getAllBuffers(buffers)
+    const matchingBuffers = allBuffers.filter((buf) => buf.file === fileName)
+
+    if (matchingBuffers.length > 0) {
+        return matchingBuffers[0]
+    } else {
+        return null
+    }
+}
+
 export const getErrors = (state: State.IState) => state.errors
 
 export const getAllErrorsForFile = (fileName: string, errors: State.Errors) => {

--- a/browser/src/UI/components/BufferScrollBar.tsx
+++ b/browser/src/UI/components/BufferScrollBar.tsx
@@ -114,12 +114,13 @@ const mapStateToProps = (state: State.IState): IBufferScrollBarProps => {
     const dimensions = Selectors.getActiveWindowDimensions(state)
 
     const file = activeWindow.file
+    const buffer = Selectors.getBufferByFilename(file, state.buffers)
 
-    if (file === null || !state.buffers[file]) {
+    if (file === null || !buffer) {
         return NoScrollBar
     }
 
-    const bufferSize = state.buffers[file].totalLines
+    const bufferSize = buffer.totalLines
 
     const markers = getMarkers(state)
 


### PR DESCRIPTION
The schema for active buffer info in the Redux store was changed, but this slipped by the TypeScript compiler for the `mapStateToProps` function for the scroll bar. This change fixes the logic so that the buffer correctly picks up the active buffer information.