### PR TITLE
Remove lodash dependency from packaged builds

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -16,12 +16,18 @@ import { Process } from "./Process"
 import { Services } from "./Services"
 import { Ui } from "./Ui"
 
+import { throttle } from "lodash/throttle"
+
 const react = require("react") // tslint:disable-line no-var-requires
 
 export class Dependencies {
     public get React(): any {
         return react
     }
+}
+
+const helpers = {
+    throttle,
 }
 
 /**
@@ -74,6 +80,10 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
 
     public get services(): Services {
         return this._services
+    }
+
+    public get helpers(): any {
+        return helpers
     }
 
     constructor(private _channel: IPluginChannel) {

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -16,7 +16,7 @@ import { Process } from "./Process"
 import { Services } from "./Services"
 import { Ui } from "./Ui"
 
-import { throttle } from "lodash/throttle"
+import * as throttle from "lodash/throttle"
 
 const react = require("react") // tslint:disable-line no-var-requires
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   "license": "MIT",
   "dependencies": {
     "find-up": "2.1.0",
-    "lodash": "4.17.0",
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
     "omnisharp-client": "7.0.6",
@@ -143,6 +142,7 @@
     "less": "2.7.1",
     "less-loader": "4.0.5",
     "less-plugin-autoprefix": "1.5.1",
+    "lodash": "4.17.0",
     "mkdirp": "0.5.1",
     "mocha": "3.1.2",
     "optimize-js-plugin": "0.0.4",

--- a/vim/core/oni-plugin-typescript/src/index.ts
+++ b/vim/core/oni-plugin-typescript/src/index.ts
@@ -10,7 +10,6 @@
 import * as os from "os"
 import * as path from "path"
 
-import * as _ from "lodash"
 import { CompletionItemKind, Diagnostic, Position, Range, SymbolKind } from "vscode-languageserver-types"
 
 import { QuickInfo } from "./QuickInfo"
@@ -265,7 +264,7 @@ export const activate = (Oni) => {
         Oni.diagnostics.setErrors("typescript-compiler", fileName, errors)
     })
 
-    const updateFile = _.throttle((bufferFullPath, stringContents) => {
+    const updateFile = Oni.helpers.throttle((bufferFullPath, stringContents) => {
         host.updateFile(bufferFullPath, stringContents)
     }, 50)
 


### PR DESCRIPTION
- Impacts #560 
- The only usage of lodash, outside of the browser bundle, was in the `throttle` call in the typescript plugin. We can expose this separately, outside of lodash, to avoid including the whole bundle.