### PR TITLE
Fix #600 - If [No Name] file isn't modified, 'Open File...' should replace it.

### DIFF
--- a/Menu.js
+++ b/Menu.js
@@ -51,7 +51,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 label: 'Open File...',
                 click: (item, focusedWindow) => {
                     dialog.showOpenDialog(mainWindow, { properties: ['openFile', 'multiSelections'] }, (files) => {
-                        executeVimCommandForFiles(":tabnew", files)
+                        executeVimCommandForMultipleFiles(":tabnew", files)
                     })
                 }
             },


### PR DESCRIPTION
- This fixes a regression brought about the 'Open File...' consolidation - thanks for catching it @CrossR !
- Uses the `executeVimCommandForMultipleFiles`, which handles the empty-file case in a nicer way.