### PR TITLE
[WIP] Windows Open With Support

### DIFF
--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -44,11 +44,11 @@ Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; Value
 function replaceForRegKeys(ext, desc) {
 
     const addFileEditor = `
-Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}.exe"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
-Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}.exe"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks: registerAsEditor;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico"; Tasks: registerAsEditor;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}${ext}"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico"; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks: registerAsEditor;
 {{RegistryKey}}
 `
     shelljs.sed("-i", "{{RegistryKey}}", addFileEditor, destFile)

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -39,7 +39,7 @@ const fileExtensions = {
 }
 
 const addToEnv = `
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\\"; Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}\\bin'))`
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}'))`
 
 function replaceForRegKeys(ext, desc) {
 

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -47,7 +47,7 @@ function replaceForRegKeys(ext, desc) {
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}${ext}"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${prodName}${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks: registerAsEditor;
-Root: HKCR; Subkey: "${prodName}${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico"; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\resources\\app.asar.unpacked\\images\\oni.ico"; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${prodName}${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks: registerAsEditor;
 {{RegistryKey}}
 `

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -44,11 +44,11 @@ Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; Value
 function replaceForRegKeys(ext, desc) {
 
     const addFileEditor = `
-Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}.exe"; Flags: deletevalue uninsdeletevalue;
-Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}.exe"; ValueData: ""; Flags: uninsdeletevalue;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico";
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1""";
+Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}.exe"; Flags: deletevalue uninsdeletevalue; Tasks registerAsEditor;
+Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}.exe"; ValueData: ""; Flags: uninsdeletevalue; Tasks registerAsEditor;
+Root: HKCR; Subkey: "${prodName}.exe\\${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks registerAsEditor;
+Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico"; Tasks registerAsEditor;
+Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks registerAsEditor;
 {{RegistryKey}}
 `
     shelljs.sed("-i", "{{RegistryKey}}", addFileEditor, destFile)

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -47,7 +47,7 @@ function replaceForRegKeys(ext, desc) {
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}${ext}"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${prodName}${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks: registerAsEditor;
-Root: HKCR; Subkey: "${prodName}${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\resources\\app.asar.unpacked\\images\\oni.ico"; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\resources\\images\\oni.ico"; Tasks: registerAsEditor;
 Root: HKCR; Subkey: "${prodName}${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks: registerAsEditor;
 {{RegistryKey}}
 `

--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -44,11 +44,11 @@ Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; Value
 function replaceForRegKeys(ext, desc) {
 
     const addFileEditor = `
-Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}.exe"; Flags: deletevalue uninsdeletevalue; Tasks registerAsEditor;
-Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}.exe"; ValueData: ""; Flags: uninsdeletevalue; Tasks registerAsEditor;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks registerAsEditor;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico"; Tasks registerAsEditor;
-Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks registerAsEditor;
+Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: none; ValueName: "${prodName}.exe"; Flags: deletevalue uninsdeletevalue; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${ext}\\OpenWithProgids"; ValueType: string; ValueName: "${prodName}.exe"; ValueData: ""; Flags: uninsdeletevalue; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}.exe\\${ext}"; ValueType: string; ValueName: ""; ValueData: "${desc}"; Flags: uninsdeletekey; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\images\\oni.ico"; Tasks: registerAsEditor;
+Root: HKCR; Subkey: "${prodName}.exe\\${ext}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks: registerAsEditor;
 {{RegistryKey}}
 `
     shelljs.sed("-i", "{{RegistryKey}}", addFileEditor, destFile)

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -23,8 +23,27 @@ WizardSmallImageFile={{WizardSmallImageFilePath}}
 [Files]
 Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
+[Tasks]
+Name: "addtopath"; Description: "Add Oni to %PATH%"; GroupDescription: "Other"
+
 [Icons]
 Name: "{group}\{{AppName}}"; Filename: "{app}\{{AppExecutableName}}"
 
 [Run]
 Filename: "{app}\{{AppExecutableName}}"; Flags: postinstall skipifsilent
+
+[Code]
+function NeedsAddPath(Param: string): boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OrigPath)
+  then begin
+    Result := True;
+    exit;
+  end;
+  Result := Pos(';' + Param + ';', ';' + OrigPath + ';') = 0;
+end;
+
+[Registry]
+{{RegistryKey}}

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -24,13 +24,14 @@ WizardSmallImageFile={{WizardSmallImageFilePath}}
 Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Tasks]
-Name: "addtopath"; Description: "Add Oni to %PATH%"; GroupDescription: "Other"
+Name: "addtopath"; Description: "Add {{AppName}} to %PATH%"; GroupDescription: "Other"
+Name: "registerAsEditor"; Description: "Register {{AppName}} as an editor"; GroupDescription: "Other"
 
 [Icons]
 Name: "{group}\{{AppName}}"; Filename: "{app}\{{AppExecutableName}}"
 
 [Run]
-Filename: "{app}\{{AppExecutableName}}"; Flags: postinstall skipifsilent
+Filename: "{app}\{{AppName}}"; Flags: postinstall skipifsilent
 
 [Code]
 function NeedsAddPath(Param: string): boolean;

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -19,6 +19,7 @@ OutputBaseFilename={{AppSetupExecutableName}}
 WizardImageFile={{WizardImageFilePath}}
 WizardImageStretch=no
 WizardSmallImageFile={{WizardSmallImageFilePath}}
+ChangesAssociations=yes
 
 [Files]
 Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs

--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ let windows = []
 // Otherwise, all other open instances will also pick up the webpack bundle
 if (!isDevelopment && !isDebug) {
     const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
-        createWindow(commandLine.slice(2), workingDirectory)
+        loadFileFromArguments(commandLine, workingDirectory)
     })
 
     if (shouldQuit) {
@@ -110,15 +110,7 @@ app.on('ready', () => {
         require("./installDevTools")
     }
 
-    const windowsOpenWith = process.platform === 'win32' &&
-                            process.argv.length === 2 && 
-                            process.argv[0].split('\\').pop() === "Oni.exe"
-    
-    if (windowsOpenWith) {
-        createWindow(process.argv.slice(1), process.cwd())
-    } else {
-        createWindow(process.argv.slice(2), process.cwd())
-    }
+    loadFileFromArguments(process, process.cwd())
 })
 
 // Quit when all windows are closed.
@@ -171,6 +163,17 @@ function focusNextInstance(direction) {
 function log(message) {
     if (isVerbose) {
         console.log(message)
+    }
+}
+
+function loadFileFromArguments(commandLine, workingDirectory) {
+    const windowsOpenWith = commandLine.platform === 'win32' &&
+                            commandLine.argv[0].split("\\").pop() === "Oni.exe"
+    
+    if (windowsOpenWith) {
+        createWindow(commandLine.argv.slice(1), workingDirectory)
+    } else {
+        createWindow(commandLine.argv.slice(2), workingDirectory)
     }
 }
 // In this file you can include the rest of your app's specific main process

--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ let windows = []
 // Otherwise, all other open instances will also pick up the webpack bundle
 if (!isDevelopment && !isDebug) {
     const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
-        loadFileFromArguments(commandLine, workingDirectory)
+        loadFileFromArguments(process.platform, commandLine, workingDirectory)
     })
 
     if (shouldQuit) {
@@ -110,7 +110,7 @@ app.on('ready', () => {
         require("./installDevTools")
     }
 
-    loadFileFromArguments(process, process.cwd())
+    loadFileFromArguments(process.platform, process.argv, process.cwd())
 })
 
 // Quit when all windows are closed.
@@ -166,14 +166,14 @@ function log(message) {
     }
 }
 
-function loadFileFromArguments(commandLine, workingDirectory) {
-    const windowsOpenWith = commandLine.platform === 'win32' &&
-                            commandLine.argv[0].split("\\").pop() === "Oni.exe"
+function loadFileFromArguments(platform, commandLine, workingDirectory) {
+    const windowsOpenWith = platform === 'win32' &&
+                            args[0].split("\\").pop() === "Oni.exe"
     
     if (windowsOpenWith) {
-        createWindow(commandLine.argv.slice(1), workingDirectory)
+        createWindow(args.slice(1), workingDirectory)
     } else {
-        createWindow(commandLine.argv.slice(2), workingDirectory)
+        createWindow(args.slice(2), workingDirectory)
     }
 }
 // In this file you can include the rest of your app's specific main process

--- a/main.js
+++ b/main.js
@@ -110,7 +110,11 @@ app.on('ready', () => {
         require("./installDevTools")
     }
 
-    if (process.platform === 'win32' && process.argv.length === 2) {
+    const windowsOpenWith = process.platform === 'win32' &&
+                            process.argv.length === 2 && 
+                            process.argv[0].split('\\').pop() === "Oni.exe"
+    
+    if (windowsOpenWith) {
         createWindow(process.argv.slice(1), process.cwd())
     } else {
         createWindow(process.argv.slice(2), process.cwd())

--- a/main.js
+++ b/main.js
@@ -166,7 +166,7 @@ function log(message) {
     }
 }
 
-function loadFileFromArguments(platform, commandLine, workingDirectory) {
+function loadFileFromArguments(platform, args, workingDirectory) {
     const windowsOpenWith = platform === 'win32' &&
                             args[0].split("\\").pop() === "Oni.exe"
     

--- a/main.js
+++ b/main.js
@@ -110,7 +110,11 @@ app.on('ready', () => {
         require("./installDevTools")
     }
 
-    createWindow(process.argv.slice(2), process.cwd())
+    if (process.platform === 'win32' && process.argv.length === 2) {
+        createWindow(process.argv.slice(1), process.cwd())
+    } else {
+        createWindow(process.argv.slice(2), process.cwd())
+    }
 })
 
 // Quit when all windows are closed.

--- a/package.json
+++ b/package.json
@@ -59,12 +59,8 @@
         "dir"
       ],
       "files": [
-        "bin/x86/**/*",
-        "images/**/*"
-      ],
-      "asarUnpack": [
-        "images"
-    ]
+        "bin/x86/**/*"
+      ]
   }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "build": {
     "asar": true,
     "asarUnpack": [
-        "bin",
-        "vim/**/*.vim"
+      "bin",
+      "vim/**/*.vim"
     ],
     "compression": "store",
     "productName": "Oni",
@@ -64,9 +64,13 @@
         "dir"
       ],
       "files": [
-        "bin/x86/**/*"
-      ]
-    }
+        "bin/x86/**/*",
+        "images/**/*"
+      ],
+      "asarUnpack": [
+        "images"
+    ]
+  }
   },
   "scripts": {
     "build": "npm run build:browser && npm run build:plugins",


### PR DESCRIPTION
Partial fix for #598.

This implements the Windows side of this, I'm not sure if other platforms have a similar issue.
Does this by adding the needed registry keys, and updating the opening of files to work for the new argument list.

Also added a fix for #344 whilst I was in this area.

I'm not especially a JS dev, so I need some advice on cleaning up the `BuildSetupTemplate.js`. Its functionally working, but its not the neatest code.
Similarly for the way I've changed main, it works but its not the nicest.

Oh, and what file types should we support right now? So far I've added text and JavaScript/TypeScript files, but there is obviously a tonne more we could add. 