### PR TITLE
Make left tab corner clickable as well

### DIFF
--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -100,7 +100,7 @@ export const Tab = (props: ITabPropsWithClick) => {
     }
 
     return <div className={cssClasses} title={props.description} style={style}>
-        <div className="corner"></div>
+        <div className="corner" onClick={props.onClickName}></div>
         <div className="name" onClick={props.onClickName}>
             <span className="name-inner">
                 {props.name}


### PR DESCRIPTION
This makes the whole tab clickable, as opposed to just the name on the tab. Thanks for the idea, @cyansprite !