### PR TITLE
Add space back to ':tabnew' command

### DIFF
--- a/Menu.js
+++ b/Menu.js
@@ -51,7 +51,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 label: 'Open File...',
                 click: (item, focusedWindow) => {
                     dialog.showOpenDialog(mainWindow, { properties: ['openFile', 'multiSelections'] }, (files) => {
-                        executeVimCommandForMultipleFiles(":tabnew", files)
+                        executeVimCommandForMultipleFiles(":tabnew ", files)
                     })
                 }
             },


### PR DESCRIPTION
- Add space back for tabnew, in order fix issue when opening multiple files after a first file has been opened
- When I ported the command over to consolidate to 'Open File', I missed that the command needed to be `:tabnew ` instead of `:tabnew`. 

This is a quick-fix to unblock #613 , but I might look at refactoring this to a 'command' so that it will show up in the commandManager.