### PR TITLE
ADDED $PATH insert/remove commands. Tasks can now use await.

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -129,6 +129,16 @@ export class NeovimEditor implements IEditor {
             }
         })
 
+        // Tasks Executed
+
+        // TODO: use constants for the built-in commands
+        this._tasks.on("task-executed", (command:String) => {
+          // reload the commands if the path has been modified
+          if (command == "oni.editor.removeFromPath" || command == "oni.editor.addToPath") {
+            registerBuiltInCommands(this._commandManager, this._pluginManager, this._neovimInstance)
+          }
+        });
+
         // TODO: Refactor `pluginManager` responsibilities outside of this instance
         this._pluginManager.on("signature-help-response", (err: string, signatureHelp: any) => { // FIXME: setup Oni import
             if (err) {

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -132,12 +132,12 @@ export class NeovimEditor implements IEditor {
         // Tasks Executed
 
         // TODO: use constants for the built-in commands
-        this._tasks.on("task-executed", (command:String) => {
+        this._tasks.on("task-executed", (command: String) => {
           // reload the commands if the path has been modified
-          if (command == "oni.editor.removeFromPath" || command == "oni.editor.addToPath") {
+          if (command === "oni.editor.removeFromPath" || command === "oni.editor.addToPath") {
             registerBuiltInCommands(this._commandManager, this._pluginManager, this._neovimInstance)
           }
-        });
+        })
 
         // TODO: Refactor `pluginManager` responsibilities outside of this instance
         this._pluginManager.on("signature-help-response", (err: string, signatureHelp: any) => { // FIXME: setup Oni import
@@ -363,7 +363,7 @@ export class NeovimEditor implements IEditor {
         document.body.ondrop = (ev) => {
             ev.preventDefault()
 
-            let files = ev.dataTransfer.files
+            const files = ev.dataTransfer.files
             // open first file in current editor
             this._neovimInstance.open(normalizePath(files[0].path))
             // open any subsequent files in new tabs

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -1,6 +1,8 @@
+/// <reference path="./../../definitions/sudo-prompt.d.ts"/>
+
+import * as fs from "fs"
 import * as os from "os"
-import * as fs from 'fs'
-const sudo = require("sudo-prompt")
+import * as sudo from "sudo-prompt"
 
 export const isWindows = () => os.platform() === "win32"
 export const isMac = () => os.platform() === "darwin"
@@ -13,27 +15,27 @@ export const getLinkPath = () => isMac() ? "/usr/local/bin/oni" : "" // TODO: wi
 
 export const pathIsLinked = () => {
   if (isMac()) {
-    try { fs.lstatSync(getLinkPath()) } catch(_) { return false }
+    try { fs.lstatSync(getLinkPath()) } catch (_) { return false }
     return true
   }
 
   return false
 }
-export const removeFromPath = () => isMac () ? fs.unlinkSync(getLinkPath()) : false; // TODO: windows + other
+export const removeFromPath = () => isMac () ? fs.unlinkSync(getLinkPath()) : false // TODO: windows + other
 
-export const addToPath = async() => {
+export const addToPath = async () => {
   if (isMac()) {
-    const appDirectory = '/Applications/Oni.app/Contents/'
-    const options = {name: 'Oni', icns: `${appDirectory}Resources/Oni.icns` };
+    const appDirectory = "/Applications/Oni.app/Contents/"
+    const options = {name: "Oni", icns: `${appDirectory}Resources/Oni.icns` }
     const linkPath = `${appDirectory}MacOS/Oni`
     await _runSudoCommand(`ln -s ${linkPath} ${getLinkPath()}`, options)
   }
 }
 
-const _runSudoCommand = async (command:string, options:any) => {
+const _runSudoCommand = async (command: string, options: any) => {
   return new Promise(resolve => {
     sudo.exec(command, options, (error: Error, stdout: string, stderr: string) => {
       resolve({error, stdout, stderr})
     })
-  });
+  })
 }

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -3,6 +3,7 @@
 import * as fs from "fs"
 import * as os from "os"
 import * as sudo from "sudo-prompt"
+import * as path from "path"
 
 export const isWindows = () => os.platform() === "win32"
 export const isMac = () => os.platform() === "darwin"
@@ -24,7 +25,7 @@ export const removeFromPath = () => isMac () ? fs.unlinkSync(getLinkPath()) : fa
 
 export const addToPath = async () => {
   if (isMac()) {
-    const appDirectory = "/Applications/Oni.app/Contents/"
+    const appDirectory = `${path.dirname(process.mainModule.filename)}../../`
     const options = {name: "Oni", icns: `${appDirectory}Resources/Oni.icns` }
     const linkPath = `${appDirectory}MacOS/Oni`
     await _runSudoCommand(`ln -s ${linkPath} ${getLinkPath()}`, options)

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -1,4 +1,6 @@
 import * as os from "os"
+import * as fs from 'fs'
+const sudo = require("sudo-prompt")
 
 export const isWindows = () => os.platform() === "win32"
 export const isMac = () => os.platform() === "darwin"
@@ -6,3 +8,32 @@ export const isLinux = () => os.platform() === "linux"
 
 export const getUserHome = () =>
     isWindows() ? process.env["USERPROFILE"] : process.env["HOME"] // tslint:disable-line no-string-literal
+
+export const getLinkPath = () => isMac() ? "/usr/local/bin/oni" : "" // TODO: windows + linux
+
+export const pathIsLinked = () => {
+  if (isMac()) {
+    try { fs.lstatSync(getLinkPath()) } catch(_) { return false }
+    return true
+  }
+
+  return false
+}
+export const removeFromPath = () => isMac () ? fs.unlinkSync(getLinkPath()) : false; // TODO: windows + other
+
+export const addToPath = async() => {
+  if (isMac()) {
+    const appDirectory = '/Applications/Oni.app/Contents/'
+    const options = {name: 'Oni', icns: `${appDirectory}Resources/Oni.icns` };
+    const linkPath = `${appDirectory}MacOS/Oni`
+    await _runSudoCommand(`ln -s ${linkPath} ${getLinkPath()}`, options)
+  }
+}
+
+const _runSudoCommand = async (command:string, options:any) => {
+  return new Promise(resolve => {
+    sudo.exec(command, options, (error: Error, stdout: string, stderr: string) => {
+      resolve({error, stdout, stderr})
+    })
+  });
+}

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -12,8 +12,7 @@ export const getUserHome = () =>
     isWindows() ? process.env["USERPROFILE"] : process.env["HOME"] // tslint:disable-line no-string-literal
 
 export const getLinkPath = () => isMac() ? "/usr/local/bin/oni" : "" // TODO: windows + linux
-
-export const pathIsLinked = () => {
+export const isAddedToPath = () => {
   if (isMac()) {
     try { fs.lstatSync(getLinkPath()) } catch (_) { return false }
     return true

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -25,9 +25,9 @@ export const removeFromPath = () => isMac () ? fs.unlinkSync(getLinkPath()) : fa
 
 export const addToPath = async () => {
   if (isMac()) {
-    const appDirectory = `${path.dirname(process.mainModule.filename)}../../`
-    const options = {name: "Oni", icns: `${appDirectory}Resources/Oni.icns` }
-    const linkPath = `${appDirectory}MacOS/Oni`
+    const appDirectory = path.join(path.dirname(process.mainModule.filename), "..", "..")
+    const options = {name: "Oni", icns: path.join(appDirectory, "Resources", "Oni.icns")}
+    const linkPath = path.join(appDirectory, "MacOS", "Oni")
     await _runSudoCommand(`ln -s ${linkPath} ${getLinkPath()}`, options)
   }
 }

--- a/browser/src/Platform.ts
+++ b/browser/src/Platform.ts
@@ -2,8 +2,8 @@
 
 import * as fs from "fs"
 import * as os from "os"
-import * as sudo from "sudo-prompt"
 import * as path from "path"
+import * as sudo from "sudo-prompt"
 
 export const isWindows = () => os.platform() === "win32"
 export const isMac = () => os.platform() === "darwin"

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -13,10 +13,15 @@ export interface ICommand {
     command: string
     name: string
     detail: string
+    messageSuccess?: string
+    messageFail?: string
     execute: (args?: any) => void
 }
 
 export class CallbackCommand implements ICommand {
+    public messageSuccess?: string
+    public messageFail?: string
+
     constructor(
         public command: string,
         public name: string,
@@ -25,6 +30,8 @@ export class CallbackCommand implements ICommand {
 }
 
 export class VimCommand implements ICommand {
+    public messageSuccess: string
+    public messageFail: string
 
     constructor(
         public command: string,
@@ -73,6 +80,8 @@ export class CommandManager implements ITaskProvider {
             name: c.name,
             detail: c.detail,
             command: c.command,
+            messageSuccess: c.messageSuccess,
+            messageFail: c.messageFail,
             callback: () => c.execute(),
         }))
 

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -30,9 +30,6 @@ export class CallbackCommand implements ICommand {
 }
 
 export class VimCommand implements ICommand {
-    public messageSuccess: string
-    public messageFail: string
-
     constructor(
         public command: string,
         public name: string, public detail: string,

--- a/browser/src/Services/CommandManager.ts
+++ b/browser/src/Services/CommandManager.ts
@@ -7,7 +7,6 @@
 import * as values from "lodash/values"
 
 import { INeovimInstance } from "./../neovim"
-
 import { ITask, ITaskProvider } from "./Tasks"
 
 export interface ICommand {
@@ -44,8 +43,11 @@ export class CommandManager implements ITaskProvider {
 
     private _commandDictionary: { [key: string]: ICommand } = {}
 
-    public registerCommand(command: ICommand): void {
+    public clearCommands(): void {
+      this._commandDictionary = {}
+    }
 
+    public registerCommand(command: ICommand): void {
         if (this._commandDictionary[command.command]) {
             console.error(`Tried to register multiple commands for: ${command.name}`)
             return
@@ -70,8 +72,10 @@ export class CommandManager implements ITaskProvider {
         const tasks = commands.map((c) => ({
             name: c.name,
             detail: c.detail,
+            command: c.command,
             callback: () => c.execute(),
         }))
+
         return Promise.resolve(tasks)
     }
 }

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -14,8 +14,8 @@ import * as UI from "./../UI/index"
 
 import { CallbackCommand, CommandManager } from "./CommandManager"
 
-import { replaceAll } from "./../Utility"
 import * as Platform from "./../Platform"
+import { replaceAll } from "./../Utility"
 
 export const registerBuiltInCommands = (commandManager: CommandManager, pluginManager: PluginManager, neovimInstance: INeovimInstance) => {
     const config = Config.instance()
@@ -86,8 +86,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
 
     if (Platform.pathIsLinked()) {
       commands.push( new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath ))
-    }
-    else {
+    } else {
       commands.push( new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath ))
     }
 

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -86,11 +86,17 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
 
     // TODO: once implementations of this command work on all platforms, remove the exclusive check for OSX
     if (Platform.isMac()) {
+      let pathCommand: CallbackCommand
+
       if (Platform.isAddedToPath()) {
-        commands.push( new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath ))
+        pathCommand = new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath )
+        pathCommand.messageSuccess = "Oni has been removed from the $PATH"
       } else {
-        commands.push( new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath ))
+        pathCommand = new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath )
+        pathCommand.messageSuccess = "Oni has been added to the $PATH"
       }
+
+      commands.push(pathCommand)
     }
 
     commands.forEach((c) => commandManager.registerCommand(c))

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -84,10 +84,13 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         // ...
     ]
 
-    if (Platform.pathIsLinked()) {
-      commands.push( new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath ))
-    } else {
-      commands.push( new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath ))
+    // TODO: once implementations of this command work on all platforms, remove the exclusive check for OSX
+    if (Platform.isMac()) {
+      if (Platform.isAddedToPath()) {
+        commands.push( new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath ))
+      } else {
+        commands.push( new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath ))
+      }
     }
 
     commands.forEach((c) => commandManager.registerCommand(c))

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -15,9 +15,12 @@ import * as UI from "./../UI/index"
 import { CallbackCommand, CommandManager } from "./CommandManager"
 
 import { replaceAll } from "./../Utility"
+import * as Platform from "./../Platform"
 
 export const registerBuiltInCommands = (commandManager: CommandManager, pluginManager: PluginManager, neovimInstance: INeovimInstance) => {
     const config = Config.instance()
+    commandManager.clearCommands()
+
     const commands = [
         new CallbackCommand("editor.clipboard.paste", "Clipboard: Paste", "Paste clipboard contents into active text", () => pasteContents(neovimInstance)),
 
@@ -80,6 +83,13 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         // Add additional commands here
         // ...
     ]
+
+    if (Platform.pathIsLinked()) {
+      commands.push( new CallbackCommand("oni.editor.removeFromPath", "Remove from PATH", "Disable executing 'oni' from terminal", Platform.removeFromPath ))
+    }
+    else {
+      commands.push( new CallbackCommand("oni.editor.addToPath", "Add to PATH", "Enable executing 'oni' from terminal", Platform.addToPath ))
+    }
 
     commands.forEach((c) => commandManager.registerCommand(c))
 }

--- a/browser/src/Services/Errors.ts
+++ b/browser/src/Services/Errors.ts
@@ -41,6 +41,7 @@ export class Errors implements ITaskProvider {
             name: "Show Errors",
             detail: "Open quickfix window and show error details",
             command: "oni.editor.showErrors",
+
             callback: () => {
                 this._setQuickFixErrors()
                 this._neovimInstance.command("copen")

--- a/browser/src/Services/Errors.ts
+++ b/browser/src/Services/Errors.ts
@@ -40,6 +40,7 @@ export class Errors implements ITaskProvider {
         const showErrorTask: ITask = {
             name: "Show Errors",
             detail: "Open quickfix window and show error details",
+            command: "oni.editor.showErrors",
             callback: () => {
                 this._setQuickFixErrors()
                 this._neovimInstance.command("copen")

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -9,6 +9,7 @@
  *  - NPM tasks
  */
 
+import {EventEmitter} from "events"
 import * as find from "lodash/find"
 import * as flatten from "lodash/flatten"
 
@@ -17,6 +18,7 @@ import * as UI from "./../UI/index"
 export interface ITask {
     name: string
     detail: string
+    command: string
     callback: () => void
 }
 
@@ -24,20 +26,22 @@ export interface ITaskProvider {
     getTasks(): Promise<ITask[]>
 }
 
-export class Tasks {
+export class Tasks extends EventEmitter {
     private _lastTasks: ITask[] = []
     private _currentBufferPath: string
 
     private _providers: ITaskProvider[] = []
 
     constructor() {
-        UI.events.on("menu-item-selected:tasks", (selectedItem: any) => {
+        super()
+        UI.events.on("menu-item-selected:tasks", async (selectedItem: any) => {
             const {label, detail} = selectedItem.selectedOption
 
             const selectedTask = find(this._lastTasks, (t) => t.name === label && t.detail === detail)
 
             if (selectedTask) {
-                selectedTask.callback()
+                await selectedTask.callback()
+                this.emit("task-executed", selectedTask.command);
             }
         })
     }

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -41,7 +41,7 @@ export class Tasks extends EventEmitter {
 
             if (selectedTask) {
                 await selectedTask.callback()
-                this.emit("task-executed", selectedTask.command);
+                this.emit("task-executed", selectedTask.command)
             }
         })
     }
@@ -71,7 +71,7 @@ export class Tasks extends EventEmitter {
     private async _refreshTasks(): Promise<void> {
         this._lastTasks = []
 
-        let initialProviders: ITaskProvider[] = []
+        const initialProviders: ITaskProvider[] = []
         const taskProviders = initialProviders.concat(this._providers)
         const allTasks = await Promise.all(taskProviders.map(async (t: ITaskProvider) => await t.getTasks() || []))
         this._lastTasks = flatten(allTasks)

--- a/browser/src/Services/Tasks.ts
+++ b/browser/src/Services/Tasks.ts
@@ -9,16 +9,18 @@
  *  - NPM tasks
  */
 
+import { remote } from "electron"
 import {EventEmitter} from "events"
 import * as find from "lodash/find"
 import * as flatten from "lodash/flatten"
-
 import * as UI from "./../UI/index"
 
 export interface ITask {
     name: string
     detail: string
     command: string
+    messageSuccess?: string
+    messageFail?: string // TODO: implement callbacks to return boolean
     callback: () => void
 }
 
@@ -42,6 +44,11 @@ export class Tasks extends EventEmitter {
             if (selectedTask) {
                 await selectedTask.callback()
                 this.emit("task-executed", selectedTask.command)
+
+                // TODO: we should make the callback return a bool so we can display either success/fail messages
+                if (selectedTask.messageSuccess != null) {
+                  remote.dialog.showMessageBox({type: "info", title: "Success", message: selectedTask.messageSuccess})
+                }
             }
         })
     }

--- a/definitions/sudo-prompt.d.ts
+++ b/definitions/sudo-prompt.d.ts
@@ -1,0 +1,1 @@
+declare module "sudo-prompt";

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "files": [
         "bin/x86/**/*"
       ]
-  }
+    }
   },
   "scripts": {
     "build": "npm run build:browser && npm run build:plugins",
@@ -158,6 +158,7 @@
     "sinon": "1.17.6",
     "spectron": "3.6.2",
     "style-loader": "0.18.2",
+    "sudo-prompt": "^7.1.1",
     "ts-loader": "2.3.2",
     "tslint": "4.0.2",
     "wcwidth": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "sinon": "1.17.6",
     "spectron": "3.6.2",
     "style-loader": "0.18.2",
-    "sudo-prompt": "^7.1.1",
+    "sudo-prompt": "7.1.1",
     "ts-loader": "2.3.2",
     "tslint": "4.0.2",
     "wcwidth": "1.0.1",


### PR DESCRIPTION
I've added the ability to Add/Remove Oni to the $PATH on OSX. It would most likely work on Linux if someone went ahead and added tweaks. I only have access to OSX right now so it's the only fix I can present.

I wanted a way to change the command to Add/Remove depending on a boolean check. This would require me to know when a task has been executed. When a task is executed, an event is now fired. I check that event for either of the two $PATH modifications and reload the commands if it was either of them.

The nature of asking a users permission (sudo) is asynchronous and so kicking off the event would have happened before the user confirmed their password, so I went ahead and made task completions async. That way, each task can now perform awaits.

Let me know if there are any thoughts. Demo:

![Demo](http://g.recordit.co/Vsx0fdHy9T.gif)