### PR TITLE
Fix config file location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ ONI currently supports the setting of a background image as well as background o
 
 By default, Oni has an opinionated, prescribed set of plugins, in order to facilitate a predictable out-of-box experience that highlights the additional UI integration points. However, this will likely have conflicts with a Vim/Neovim veteran's finely-honed configuration.
 
-To avoid loading the Oni defaults, and instead use your `init.vim`, set this configuration value to false in $HOME/.oni/config.json.
+To avoid loading the Oni defaults, and instead use your `init.vim`, set this configuration value to false in `$HOME/.oni/config.js`.
 
 ### Included VIM Plugins
 


### PR DESCRIPTION
Support for `config.json` was removed in e7e14356fe6db3cd8ee2f1fd94b7ed1919cdf119.