### PR TITLE
Fix #434 - Paste in commandline by allowing paste gesture when in commandline

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -290,13 +290,15 @@ export class NeovimEditor implements IEditor {
             // TODO: Untangle these nested conditionals to use our new input-binding strategy :)
             if (Config.instance().getValue("editor.clipboard.enabled")) {
 
+                const isInsertMode = this._screen.mode === "insert" || this._screen.mode === "cmdline_normal"
+
                 // Handling the platform-default cases should be done when we initialize
                 // default key bindings, prior to loading hte config
                 if (Platform.isLinux() || Platform.isWindows()) {
                     if (key === "<C-c>" && this._screen.mode === "visual") {
                         this._neovimInstance.input("y")
                         return
-                    } else if (key === "<C-v>" && this._screen.mode === "insert") {
+                    } else if (key === "<C-v>" && isInsertMode) {
                         this._commandManager.executeCommand("editor.clipboard.paste", null)
                         return
                     }
@@ -306,7 +308,7 @@ export class NeovimEditor implements IEditor {
                         // execute out of visual mode, but yank
                         this._neovimInstance.input("y")
                         return
-                    } else if (key === "<M-v>" && this._screen.mode === "insert") {
+                    } else if (key === "<M-v>" && isInsertMode) {
                         this._commandManager.executeCommand("editor.clipboard.paste", null)
                         return
                     }

--- a/browser/src/Screen.ts
+++ b/browser/src/Screen.ts
@@ -2,7 +2,7 @@ import * as Actions from "./actions"
 import { IDeltaRegionTracker } from "./DeltaRegionTracker"
 import { Grid } from "./Grid"
 
-export type Mode = "insert" | "normal" | "visual"
+export type Mode = "insert" | "normal" | "visual" | "cmdline_normal"
 
 const wcwidth = require("wcwidth") // tslint:disable-line no-var-requires
 


### PR DESCRIPTION
__Issue:__ Should be able to use the paste gestures in command-line mode

__Defect:__ We were just checking if mode is `insert`, but the command line has its own mode (`commandline_normal`).

__Fix:__ Allow paste in both modes.

Fixes #434 