### PR TITLE
Fix #665 - Cursor should be block in visual mode

### DIFF
--- a/browser/src/UI/components/Cursor.tsx
+++ b/browser/src/UI/components/Cursor.tsx
@@ -25,9 +25,9 @@ class CursorRenderer extends React.PureComponent<ICursorProps, void> {
         const fontFamily = this.props.fontFamily
         const fontSize = this.props.fontSize
 
-        const isNormalMode = this.props.mode === "normal"
-        const width = isNormalMode ? this.props.width : this.props.width / 4
-        const characterToShow = isNormalMode ? this.props.character : ""
+        const isInsertCursor = this.props.mode === "insert" || this.props.mode === "cmdline_normal"
+        const width = isInsertCursor ? this.props.width / 4 : this.props.width
+        const characterToShow = isInsertCursor ? "" : this.props.character
 
         const cursorStyle: React.CSSProperties = {
             position: "absolute",


### PR DESCRIPTION
__Issue:__ In visual mode, we would show the _insert_ cursor, which is confusing and disorienting, since this isn't what vim does

__Defect:__ The conditional to determine cursor shape would default to the _insert_ cursor, unless in _normal_ mode.

__Fix:__ Update logic to use the _insert_ cursor for insert mode (or cmdline_normal) mode, and the _block_ cursor otherwise (which captures the visual modes)

Fixes #665 