### PR TITLE
#663 Fix: preventDefault on keyCode 13

### DIFF
--- a/browser/src/Input/Keyboard.ts
+++ b/browser/src/Input/Keyboard.ts
@@ -5,6 +5,14 @@ export class Keyboard extends EventEmitter {
         super()
 
         document.addEventListener("keydown", (evt) => {
+            /*
+             * This prevents the opening and immediate
+             * (unwanted) closing of external windows.
+             * This problem seems to only exist in Mac OS.
+             */
+            if (evt.keyCode === 13) {
+                evt.preventDefault()
+            }
             const vimKey = this._convertKeyEventToVimKey(evt)
             const mappedKey = this._wrapWithBracketsAndModifiers(vimKey, evt)
 


### PR DESCRIPTION
As noted in #663, this only pops up in Mac OS. It seems that when opening the Finder the `keydown` event makes Oni lose focus (which is deferred to the Finder window), and the accompanying `keyup` event is asserted in the Finder as a user click. It didn't seem possible to `evt.preventDefault()` on the `keyup` from within the Oni instance as focus was lost at this point. To avoid this issue...

* in `Input/Keyboard.ts`:
    - `document.addEventListener("keydown"...` check if `keyCode` is 13, if so `preventDefault`

This seems counterproductive at first, but Oni handles `Enter` events on its own so the event itself doesn't need to propagate outward. This prevents Mac's Finder from swallowing the `keyup` event when Oni loses focus.

I tested this on Linux to make sure it didn't have any weird side effects. None were found. I don't have an easy way to test on Windows unfortunately.