### PR TITLE
Normalize path for "Save As".

### DIFF
--- a/Menu.js
+++ b/Menu.js
@@ -110,7 +110,7 @@ const buildMenu = (mainWindow, loadInit) => {
                 click (item, focusedWindow) {
                     dialog.showSaveDialog(mainWindow, {}, (name) => {
                         if (name) {
-                            executeVimCommand(":save " + name)
+                            executeVimCommand(":save " + normalizePath(name))
                         }
                     })
                 }


### PR DESCRIPTION
"Save As" isn't working for me on Windows, as the path isn't normalised so forward slashes are lost.
Using the existing `normalisePath` function seems to have fixed this for me.