### PR TITLE
Fix #628 - Paste fixes

### DIFF
--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -176,10 +176,15 @@ const quickOpenFile = popupMenuCommand(() => UI.Actions.selectMenuItem("e"))
 const quickOpenFileHorizontal = popupMenuCommand(() => UI.Actions.selectMenuItem("sp"))
 const quickOpenFileVertical = popupMenuCommand(() => UI.Actions.selectMenuItem("vsp"))
 
-const pasteContents = (neovimInstance: INeovimInstance) => {
+const pasteContents = async (neovimInstance: INeovimInstance) => {
     const textToPaste = clipboard.readText()
     const sanitizedText = replaceAll(textToPaste, { "<": "<lt>" })
-    neovimInstance.input(sanitizedText)
+                            .split("/r/n")
+                            .join("/n")
+
+    await neovimInstance.command("set paste")
+    await neovimInstance.input(sanitizedText)
+    await neovimInstance.command("set nopaste")
 }
 
 const openFolder = (neovimInstance: INeovimInstance) => {

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -4,6 +4,8 @@
  * Built-in Oni Commands
  */
 
+import * as os from "os"
+
 import { remote } from "electron"
 
 import * as Config from "./../Config"
@@ -179,8 +181,8 @@ const quickOpenFileVertical = popupMenuCommand(() => UI.Actions.selectMenuItem("
 const pasteContents = async (neovimInstance: INeovimInstance) => {
     const textToPaste = clipboard.readText()
     const sanitizedText = replaceAll(textToPaste, { "<": "<lt>" })
-                            .split("/r/n")
-                            .join("/n")
+                            .split(os.EOL)
+                            .join("<cr>")
 
     await neovimInstance.command("set paste")
     await neovimInstance.input(sanitizedText)


### PR DESCRIPTION
__Issue:__ The current paste behavior with `editor.clipboard.enabled` is slow, is impacted by auto-indent, and adds extra newlines.

__Fix:__ Vim provides a setting for this - `paste`/`nopaste`, so we should be leveraging that prior to bringing in pasted text. In addition, the newlines should be sanitized to `<cr>`.