### PR TITLE
Add `neovim` capability to `Editor` API

### DIFF
--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -5,14 +5,7 @@ import { IEvent } from "./../Event"
  * an editor handles rendering and input
  * for a specific window.
  */
-export interface IEditor {
-
-    // Members
-    mode: string
-
-    // Events
-    onModeChanged: IEvent<string>
-
+export interface IEditor extends Oni.Editor {
     // Methods
     init(filesToOpen: string[]): void
     render(): JSX.Element

--- a/browser/src/Editor/Editor.ts
+++ b/browser/src/Editor/Editor.ts
@@ -1,5 +1,3 @@
-import { IEvent } from "./../Event"
-
 /**
  * Interface that describes an Editor -
  * an editor handles rendering and input

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -72,6 +72,11 @@ export class NeovimEditor implements IEditor {
         return this._onModeChangedEvent
     }
 
+    // Capabilities
+    public get neovim(): Oni.NeovimEditorCapability {
+        return this._neovimInstance
+    }
+
     constructor(
         private _pluginManager: PluginManager,
         private _config: Config.Config = Config.instance(),

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -60,6 +60,14 @@ export class ActiveEditor implements Oni.Editor {
         return this._activeEditor.mode
     }
 
+    public get neovim(): Oni.NeovimEditorCapability {
+        if (!this._activeEditor) {
+            return null
+        }
+
+        return this._activeEditor.neovim
+    }
+
     public get onModeChanged(): IEvent<string> {
         return this._onModeChanged
     }

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -35,9 +35,20 @@ declare namespace Oni {
         unbindAll()
     }
 
+    export interface NeovimEditorCapability {
+        // Send a direct set of key inputs to Neovim
+        input(keys: string): Promise<void>
+
+        // Evaluate an expression, and return the result
+        eval(expression: string): Promise<any>
+    }
+
     export interface Editor {
         mode: string
         onModeChanged: IEvent<string>
+
+        // Optional capabilities for the editor to implement
+        neovim?: NeovimEditorCapability
     }
 
     export interface Commands {

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -41,6 +41,9 @@ declare namespace Oni {
 
         // Evaluate an expression, and return the result
         eval(expression: string): Promise<any>
+
+        // Execute a command
+        command(command: string): Promise<void>
     }
 
     export interface Editor {


### PR DESCRIPTION
This change extends the plugin API surface by adding a `neovim` property to the activeEditor instance, allowing a direct interface to Neovim.

This opens up the ability for keybindings to do more interesting things, like send direct input to Neovim via `activeEditor.neovim.input`, or running commands:
```
    const echo = (msg) => {
        const activeEditor = oni.editors.activeEditor

        if (activeEditor && activeEditor.neovim) {
            activeEditor.neovim.command(`echo '${msg}'`)
        }
    }

    oni.input.bind("<c-enter>", () => echo("Control+Enter was pressed"))
```