### PR TITLE
0.2.9: Fix OS X zip artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
       file_glob: true
       file:
         - dist/*.dmg
-        - dist/mac/*.zip
+        - dist/*.zip
       skip_cleanup: true
       on:
         condition: $TRAVIS_OS_NAME = osx

--- a/main/src/Log.ts
+++ b/main/src/Log.ts
@@ -6,14 +6,20 @@
 
 const logs = []
 
+const isVerbose = process.argv.filter(arg => arg.indexOf("--verbose") >= 0).length > 0
+
 export const info = (msg: string): void => {
-    console.log(msg) // tslint:disable-line no-console
+    if (isVerbose) {
+        console.log(msg) // tslint:disable-line no-console
+    }
 
     logs.push(msg)
 }
 
 export const warn = (msg: string): void => {
-    console.warn(msg) // tslint:disable-line no-console
+    if (isVerbose) {
+        console.warn(msg) // tslint:disable-line no-console
+    }
 
     logs.push(msg)
 }


### PR DESCRIPTION
__Issue:__ The OS X release was not publish the .zip archive

__Defect:__ The latest electron-builder now puts it directly in the `dist` folder as opposed to `dist/mac`

__Fix:__ Update `.travis.yml` to set the path properly