### PR TITLE
Update .travis.yml to properly publish OSX zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
       file_glob: true
       file:
         - dist/*.dmg
-        - dist/mac/*.zip
+        - dist/*.zip
       skip_cleanup: true
       on:
         condition: $TRAVIS_OS_NAME = osx


### PR DESCRIPTION
__Issue:__ The OS X release was not publish the .zip archive

__Defect:__ The latest electron-builder now puts it directly in the `dist` folder as opposed to `dist/mac`

__Fix:__ Update `.travis.yml` to set the path properly