### PR TITLE
Integrate 'keyboard-layout' npm module and additional diagnostic logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
 addons:
     apt:
         packages:
-            - clang-3.3
-            - libx11-dev
             - libxkbfile-dev
             - libgnome-keyring-dev
             - icnsutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
 addons:
     apt:
         packages:
+            - clang-3.3
+            - libx11-dev
+            - libxkbfile-dev
             - libgnome-keyring-dev
             - icnsutils
             - graphicsmagick

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ A [tar.gz](https://github.com/extr0py/oni/releases/download/v0.2.9/Oni-0.2.9-lin
 
 ### Build
 
+> Ensure all dependencies for [node-gyp](https://github.com/nodejs/node-gyp) are installed, as some modules require building native code.
+
 1) Clone the repository: `git clone https://github.com/extr0py/oni.git`
 
 2) Install dependencies by running `npm install` from the root

--- a/browser/src/Input/Keyboard.ts
+++ b/browser/src/Input/Keyboard.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "events"
 
+import * as Log from "./../Log"
+
 // List taken from:
 // https://github.com/zeit/hyper/blob/7a08b1dc3e07ae552debfe7e62c48b0a5a028ff9/lib/utils/key-code.js
 const suppressShiftKeyCharacters = [
@@ -43,6 +45,8 @@ export class Keyboard extends EventEmitter {
 
             const vimKey = this._convertKeyEventToVimKey(evt)
             const mappedKey = this._wrapWithBracketsAndModifiers(vimKey, evt)
+
+            Log.debug(`[Key event] Code: ${evt.code} Key: ${evt.key} CtrlKey: ${evt.ctrlKey} ShiftKey: ${evt.shiftKey} AltKey: ${evt.altKey} | Resolution: ${mappedKey}`)
 
             if (mappedKey) {
                 this.emit("keydown", mappedKey)

--- a/browser/src/Log.ts
+++ b/browser/src/Log.ts
@@ -4,18 +4,38 @@
  * Utilities for logging in Oni
  */
 
-export function debug(message: string): void {
+// For now, `isVerboseLoggingEnabled` will handle both `debug` and `verbose` levels.
+// (and on by default for development builds)
+let isVerboseLoggingEnabled = process.env["NODE_ENV"] === "development"
+
+export const debug = (message: string): void => {
+    if (isVerboseLoggingEnabled) {
+        console.log(message) // tslint:disable-line no-console
+    }
+}
+
+export const verbose = (message: string): void => {
+    if (isVerboseLoggingEnabled) {
+        console.log(message)
+    }
+}
+
+export const info = (message: string): void  => {
     console.log(message) // tslint:disable-line no-console
 }
 
-export function info(message: string): void {
-    console.log(message) // tslint:disable-line no-console
-}
-
-export function warn(message: string): void {
+export const warn = (message: string): void  => {
     console.warn(message) // tslint:disable-line no-console
 }
 
-export function error(messageOrError: string | Error, errorDetails?: any): void {
+export const error = (messageOrError: string | Error, errorDetails?: any): void => {
     console.error(messageOrError) // tslint:disable-line no-console
+}
+
+export const enableVerboseLogging = () => {
+    isVerboseLoggingEnabled = true
+}
+
+export const disableVerboseLogging = () => {
+    isVerboseLoggingEnabled = false
 }

--- a/browser/src/Log.ts
+++ b/browser/src/Log.ts
@@ -6,7 +6,7 @@
 
 // For now, `isVerboseLoggingEnabled` will handle both `debug` and `verbose` levels.
 // (and on by default for development builds)
-let isVerboseLoggingEnabled = process.env["NODE_ENV"] === "development"
+let isVerboseLoggingEnabled = process.env["NODE_ENV"] === "development" // tslint:disable-line no-string-literal
 
 export const debug = (message: string): void => {
     if (isVerboseLoggingEnabled) {
@@ -16,7 +16,7 @@ export const debug = (message: string): void => {
 
 export const verbose = (message: string): void => {
     if (isVerboseLoggingEnabled) {
-        console.log(message)
+        console.log(message) // tslint:disable-line no-console
     }
 }
 

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -53,6 +53,10 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         return this._commands
     }
 
+    public get log(): Oni.Log {
+        return Log
+    }
+
     public get configuration(): Oni.Configuration {
         return this._configuration
     }

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -58,6 +58,14 @@ declare namespace Oni {
         registerCommand(commandName: string, callback: (args?: any) => void): void
     }
 
+    export interface Log {
+        verbose(msg: string): void
+        info(msg: string): void
+
+        disableVerboseLogging(): void
+        enableVerboseLogging(): void
+    }
+
     export interface StatusBar {
         getItem(globalId?: string): StatusBarItem
         createItem(alignment: number, priority: number, globalId?: string): StatusBarItem

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "watch:browser": "webpack-dev-server --config browser/webpack.debug.config.js --host localhost --port 8191",
     "watch:plugins": "cd vim/core/oni-plugin-typescript && tsc --watch",
     "uninstall-global": "npm rm -g oni-vim",
-    "install-global": "npm install -g oni-vim"
+    "install-global": "npm install -g oni-vim",
+    "postinstall": "electron-rebuild"
   },
   "repository": {
     "type": "git",
@@ -138,6 +139,7 @@
     "electron": "1.7.7",
     "electron-builder": "19.26.0",
     "electron-devtools-installer": "2.2.0",
+    "electron-rebuild": "^1.6.0",
     "extract-zip": "1.6.0",
     "fuse.js": "2.6.2",
     "glob": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "electron": "1.7.7",
     "electron-builder": "19.26.0",
     "electron-devtools-installer": "2.2.0",
-    "electron-rebuild": "^1.6.0",
+    "electron-rebuild": "1.6.0",
     "extract-zip": "1.6.0",
     "fuse.js": "2.6.2",
     "glob": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "license": "MIT",
   "dependencies": {
     "find-up": "2.1.0",
+    "keyboard-layout": "2.0.13",
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
     "typescript": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint:main": "tslint --project main/tsconfig.json --config tslint.json",
     "lint:test": "tslint --project test/tsconfig.json --config tslint.json && tslint vim/core/oni-plugin-typescript/src/**/*.ts",
     "start": "concurrently --kill-others \"npm run start-hot\" \"npm run watch:browser\" \"npm run watch:plugins\"",
-    "start-hot": "cross-env NODE_ENV=development electron main.js",
+    "start-hot": "cross-env NODE_ENV=development electron lib/main/src/main.js",
     "start-not-dev": "cross-env electron main.js",
     "watch:browser": "webpack-dev-server --config browser/webpack.debug.config.js --host localhost --port 8191",
     "watch:plugins": "cd vim/core/oni-plugin-typescript && tsc --watch",

--- a/vim/core/oni-plugin-typescript/src/index.ts
+++ b/vim/core/oni-plugin-typescript/src/index.ts
@@ -188,7 +188,7 @@ export const activate = (Oni) => {
             })
         }
 
-        Oni.log.verbose("Get completions: current line " + currentLine) // tslint:disable-line no-console
+        Oni.log.verbose("Get completions: current line " + currentLine)
 
         return host.getCompletions(textDocumentPosition.bufferFullPath, textDocumentPosition.line, textDocumentPosition.column, currentPrefix)
             .then((val: any[]) => {

--- a/vim/core/oni-plugin-typescript/src/index.ts
+++ b/vim/core/oni-plugin-typescript/src/index.ts
@@ -188,7 +188,7 @@ export const activate = (Oni) => {
             })
         }
 
-        console.log("Get completions: current line " + currentLine) // tslint:disable-line no-console
+        Oni.log.verbose("Get completions: current line " + currentLine) // tslint:disable-line no-console
 
         return host.getCompletions(textDocumentPosition.bufferFullPath, textDocumentPosition.line, textDocumentPosition.column, currentPrefix)
             .then((val: any[]) => {


### PR DESCRIPTION
There are several keyboard related issues around `AltGr` and improper shift key behavior. There have been several hacks added to the `Keyboard.ts` to try and workaround it, but a more robust solution is needed to handle these cases across all keyboard layouts.

This is adds Atom's [keyboard-layout](https://www.npmjs.com/package/keyboard-layout) package, which allows Oni to resolve characters properly.

The problem for these cases is that, Oni needs to decide whether to append `<C-` or `<S-` or `<A-` to characters. In the `AltGr` case, we improperly send down `<A-(character)>`, and in some of the shift cases, we improperly send down `<S-(character)>`, neither of these are recognized in insert mode.

With the _keyboard-layout_ module, we can ask the current layout what the expected character is with shift & altgraph, and determine robustly whether we should ignore the shift/alt keys.

One issue is that the _keyboard-layout_ module requires building native modules from source, so as part of build the prerequisites that are listed here need to be addressed: https://github.com/nodejs/node-gyp

(Specifically, python and C++ tools are required to build Oni, now).

In addition, the _keyboard-layout_ module also makes it easy to determine which keyboard layout is currently active, which is not possible in just the electron context.
