### PR TITLE
Use 'nord' colorscheme by default

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -275,7 +275,7 @@ const BaseConfiguration: IConfigurationValues = {
     "tabs.wrap": false,
 
     "ui.animations.enabled": true,
-    "ui.colorscheme": "onedark",
+    "ui.colorscheme": "nord",
     "ui.iconTheme": "theme-icons-seti",
     "ui.fontFamily":
         "BlinkMacSystemFont, 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",


### PR DESCRIPTION
This change modifies the default colorscheme to use `nord` instead of `onedark`. The reason behind this change is that I want Oni to have a unique visual style - today, we use the `onedark` theme, which is the same theme Atom uses. 

I want to visually differentiate Oni from other editors (hopefully in a positive way!), and I think the `nord` colorscheme is a good choice.

Of course, if you prefer `onedark`, make sure to set `"ui.colorscheme": "onedark"` in your `config.js`