### PR TITLE
Bugfix: FileSystemWatcher - crash when there is an error

### DIFF
--- a/browser/src/Services/FileSystemWatcher/index.ts
+++ b/browser/src/Services/FileSystemWatcher/index.ts
@@ -2,6 +2,8 @@ import * as chokidar from "chokidar"
 import { Stats } from "fs"
 import { Event, IEvent } from "oni-types"
 
+import * as Log from "./../../Log"
+
 export type Targets = string | string[]
 
 interface IFSOptions {
@@ -33,6 +35,10 @@ export class FileSystemWatcher {
 
         this._watcher.on("ready", () => {
             this._attachEventListeners()
+        })
+
+        this._watcher.on("error", err => {
+            Log.warn("FileSystemWatcher encountered an error: " + err)
         })
     }
 


### PR DESCRIPTION
__Issue:__ On Windows, I noticed that when I built the unit tests, Oni would crash and just show a blank screen.

__Defect:__ `chokidar` was emitting several error events around the fileysystem, for exampe:
```
events.js:182 Uncaught Error: EPERM: operation not permitted, lstat 'E:\oni\lib_test\browser\src\Input'
```
This was easy to repro on Windows by running `npm run test:unit:browser` while the `E:/oni` directory was the active workspace, or by deleting the `lib_test` folder.

__Fix:__ Handle the 'error' event and log out warnings. These aren't usually actionable for us, and are just noise - for example, it's expected when the `lib_test` folder is deleted that you'd get an error trying to access a subdirectory, and we don't need to do anything special. However, handling the error event means it doesn't bubble up and crash the editor.
